### PR TITLE
Remove hardcoded llama-cli path

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1,6 +1,6 @@
 import os, subprocess, textwrap
 
-LLAMA_CPP_BINARY = os.getenv("LLAMA_CPP_BIN", "/Users/aj/git/llama.cpp/build/bin/llama-cli")
+LLAMA_CPP_BINARY = os.getenv("LLAMA_CPP_BIN", "llama-cli")
 
 ANSWER_START = "<<<ANSWER>>>"
 ANSWER_END   = "<<<END>>>"


### PR DESCRIPTION
- If llama.cpp is installed correctly, the system should be able to locate it
- f not, the user can specify the location by setting `LLAMA_CPP_BINARY`
- the path `/Users/aj/git/llama.cpp/build/bin/llama-cli` only exists on AJ's computer