### PR TITLE
Partial Indexing - CLI Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ data/
 *.faiss
 *.pkl
 index/cache/
+index/partial_sections
 
 # --- Model files ---
 models/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help env build-llama clean test run-index run-chat install update-env
+.PHONY: help env build-llama clean test run-index run-chat run-index-partial run-add-chapters-partial run-chat-partial install update-env
 
 help:
 	@echo "TokenSmith - RAG Application (Conda Dependencies)"
@@ -11,6 +11,9 @@ help:
 	@echo "  clean       - Clean build artifacts"
 	@echo "  show-deps   - Show installed conda packages"
 	@echo "  export-env  - Export current environment"
+	@echo "  run-index-partial - Create a partial index (e.g., make run-index-partial CHAPTERS=\"1 2\")"
+	@echo "  run-add-chapters-partial - Add chapters to partial index (e.g., make run-add-chapters-partial CHAPTERS=\"3\")"
+	@echo "  run-chat-partial - Chat using partial index"
 
 # Environment setup - installs all dependencies via conda
 env:
@@ -73,3 +76,15 @@ run-chat:
 	@echo "Note: Chat mode requires interactive terminal. If this fails, use:"
 	@echo "  conda activate tokensmith && python -m src.main chat $(ARGS)"
 	conda run --no-capture-output -n tokensmith --no-capture-output python -m src.main chat $(ARGS)
+
+run-index-partial:
+	@echo "Running TokenSmith partial index mode with chapters: $(CHAPTERS) $(ARGS)"
+	conda run --no-capture-output -n tokensmith python -m src.main index --partial --chapters $(CHAPTERS) $(ARGS)
+
+run-add-chapters-partial:
+	@echo "Adding chapters $(CHAPTERS) to partial index with ARGS: $(ARGS)"
+	conda run --no-capture-output -n tokensmith python -m src.main add-chapters --partial --chapters $(CHAPTERS) $(ARGS)
+
+run-chat-partial:
+	@echo "Running TokenSmith chat mode (partial index) with additional CLI args: $(ARGS)"
+	conda run --no-capture-output -n tokensmith --no-capture-output python -m src.main chat --partial $(ARGS)

--- a/src/config.py
+++ b/src/config.py
@@ -94,15 +94,41 @@ class RAGConfig:
             return SectionRecursiveStrategy(self.chunk_config)
         raise ValueError(f"Unknown chunk config type: {self.chunk_config.__class__.__name__}")
 
-    def get_artifacts_directory(self) -> os.PathLike:
-        """Returns the path prefix for index artifacts."""
+    def get_artifacts_directory(self, partial: bool = False) -> os.PathLike:
+        """
+        Returns the path prefix for index artifacts.
+        If partial=True, strictly returns the partial directory.
+        If partial=False, returns the main directory if it exists, 
+        otherwise falls back to the partial directory.
+        """
         strategy = self.get_chunk_strategy()
-        strategy_dir = pathlib.Path("index", strategy.artifact_folder_name())
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        return strategy_dir
+        base_folder = strategy.artifact_folder_name()
+        
+        main_dir = pathlib.Path("index", base_folder)
+        partial_dir = pathlib.Path("index", f"partial_{base_folder}")
 
-    def get_config_state(self) -> dict:
-        """Returns dict of all config parameters except chunk_config."""
+        if partial:
+            target_dir = partial_dir
+            print("Using partial directory (change partial to false in config.yaml to use full directory)")
+        else:
+            # Fallback logic: use main if it exists, otherwise use partial if it exists
+            if main_dir.exists():
+                target_dir = main_dir
+            elif partial_dir.exists():
+                target_dir = partial_dir
+                print("Using partial directory (unable to find full directory)")
+            else:
+                target_dir = main_dir
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        return target_dir
+
+    def get_page_to_chunk_map_path(self, artifacts_dir: os.PathLike, index_prefix: str) -> os.PathLike:
+        """Returns the path to the page-to-chunk map file."""
+        return pathlib.Path(artifacts_dir) / f"{index_prefix}_page_to_chunk_map.json"
+    
+    def get_config_state(self) -> None:
+        """Returns dict of all config parameters except chunk_config """
         state = self.__dict__.copy()
         state.pop("chunk_config", None)
         for key in list(state.keys()):

--- a/src/index_builder.py
+++ b/src/index_builder.py
@@ -9,7 +9,7 @@ import pickle
 import pathlib
 import re
 import json
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 import numpy as np
 import faiss
@@ -41,6 +41,7 @@ def build_index(
     index_prefix: str,
     use_multiprocessing: bool = False,
     use_headings: bool = False,
+    chapters_to_index: Optional[List[int]] = None
 ) -> None:
     """
     Extract sections, chunk, embed, and build both FAISS and BM25 indexes.
@@ -61,6 +62,9 @@ def build_index(
         markdown_file,
         exclusion_keywords=DEFAULT_EXCLUSION_KEYWORDS
     )
+    
+    if chapters_to_index:
+        sections = [s for s in sections if s.get('chapter') in chapters_to_index]
 
     page_to_chunk_ids = {}
     current_page = 1
@@ -191,6 +195,21 @@ def build_index(
         pickle.dump(metadata, f)
     print(f"Saved all index artifacts with prefix: {index_prefix}")
 
+    output_file = artifacts_dir / f"{index_prefix}_info.json"
+    index_info = {
+        "textbooks": [
+            {
+                "markdown_file": markdown_file,
+                "chapters": chapters_to_index if chapters_to_index else ["all"],
+                "status": "partial" if chapters_to_index else "full"
+            }
+        ]
+    }
+    with open(output_file, "w") as f:
+        json.dump(index_info, f, indent=2)
+    print(f"Saved index information: {output_file}")
+
+# ------------------------ Helper functions ------------------------------
 
 def preprocess_for_bm25(text: str) -> list[str]:
     """Lowercase and tokenize text for BM25 indexing."""

--- a/src/index_updater.py
+++ b/src/index_updater.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+index_updater.py
+Adds new chapters to an existing index.
+"""
+
+import os
+import pickle
+import pathlib
+import json
+import re
+from typing import List, Dict, Optional
+
+import faiss
+from rank_bm25 import BM25Okapi
+from src.embedder import SentenceTransformer
+
+from src.preprocessing.chunking import DocumentChunker, ChunkConfig
+from src.preprocessing.extraction import extract_sections_from_markdown
+from src.index_builder import build_index, preprocess_for_bm25
+
+DEFAULT_EXCLUSION_KEYWORDS = ['questions', 'exercises', 'summary', 'references']
+
+def add_to_index(
+    markdown_file: str,
+    *,
+    chunker: DocumentChunker,
+    chunk_config: ChunkConfig,
+    embedding_model_path: str,
+    embedding_model_context_window: int,
+    artifacts_dir: os.PathLike,
+    index_prefix: str,
+    chapters_to_add: List[int],
+    use_multiprocessing: bool = False,
+    use_headings: bool = False,
+) -> None:
+    """
+    Adds new chapters to an existing FAISS and BM25 index.
+    If an index does not exist, it creates a new one.
+    """
+    artifacts_dir = pathlib.Path(artifacts_dir)
+    faiss_index_path = artifacts_dir / f"{index_prefix}.faiss"
+    bm25_index_path = artifacts_dir / f"{index_prefix}_bm25.pkl"
+    chunks_path = artifacts_dir / f"{index_prefix}_chunks.pkl"
+    sources_path = artifacts_dir / f"{index_prefix}_sources.pkl"
+    meta_path = artifacts_dir / f"{index_prefix}_meta.pkl"
+    info_path = artifacts_dir / f"{index_prefix}_info.json"
+    map_path = artifacts_dir / f"{index_prefix}_page_to_chunk_map.json"
+
+    if not faiss_index_path.exists():
+        print("No existing index found. Building a new one...")
+        build_index(
+            markdown_file=markdown_file,
+            chunker=chunker,
+            chunk_config=chunk_config,
+            embedding_model_path=embedding_model_path,
+            embedding_model_context_window=embedding_model_context_window,
+            artifacts_dir=artifacts_dir,
+            index_prefix=index_prefix,
+            use_multiprocessing=use_multiprocessing,
+            use_headings=use_headings,
+            chapters_to_index=chapters_to_add,
+        )
+        return
+
+    print(f"Adding chapters {chapters_to_add} to existing index...")
+
+    # Load existing artifacts
+    with open(chunks_path, "rb") as f:
+        existing_chunks = pickle.load(f)
+    with open(sources_path, "rb") as f:
+        existing_sources = pickle.load(f)
+    with open(meta_path, "rb") as f:
+        existing_metadata = pickle.load(f)
+    with open(info_path, "r") as f:
+        index_info = json.load(f)
+
+    if map_path.exists():
+        with open(map_path, "r") as f:
+            page_to_chunk_ids = {int(k): set(v) for k, v in json.load(f).items()}
+    else:
+        page_to_chunk_ids = {}
+
+    target_textbook = next((t for t in index_info["textbooks"] if t["markdown_file"] == markdown_file), None)
+
+    if target_textbook:
+        existing_chapters = target_textbook.get("chapters", [])
+    else:
+        existing_chapters = []
+
+    if "all" in existing_chapters:
+        print("Index contains all chapters. No new chapters to add.")
+        return
+
+    chapters_to_index = list(set(chapters_to_add) - set(existing_chapters))
+
+    if not chapters_to_index:
+        print("All requested chapters are already in the index.")
+        return
+
+    # Extract sections for the new chapters
+    sections = extract_sections_from_markdown(
+        markdown_file,
+        exclusion_keywords=DEFAULT_EXCLUSION_KEYWORDS
+    )
+    new_sections = [s for s in sections if s.get('chapter') in chapters_to_index]
+
+    if not new_sections:
+        print("No new sections found for the given chapters.")
+        return
+
+    new_chunks: List[str] = []
+    new_sources: List[str] = []
+    new_metadata: List[Dict] = []
+
+    total_chunks = len(existing_chunks)
+    current_page = max([m.get('page_number', 1) for m in existing_metadata]) if existing_metadata else 1
+    heading_stack = []
+
+    page_pattern = re.compile(r'--- Page (\d+) ---')
+
+    for i, c in enumerate(new_sections):
+        current_level = c.get('level', 1)
+        chapter_num = c.get('chapter', 0)
+
+        while heading_stack and heading_stack[-1][0] >= current_level:
+            heading_stack.pop()
+
+        if c['heading'] != "Introduction":
+            heading_stack.append((current_level, c['heading']))
+
+        path_list = [h[1] for h in heading_stack]
+        full_section_path = " ".join(path_list)
+        full_section_path = f"Chapter {chapter_num} " + full_section_path
+
+        sub_chunks = chunker.chunk(c['content'])
+
+        for sub_chunk_id, sub_chunk in enumerate(sub_chunks):
+            chunk_pages = set()
+            fragments = page_pattern.split(sub_chunk)
+            current_chunk_global_id = total_chunks + len(new_chunks)
+
+            # If there is content before the first page marker, it belongs to the current_page.
+            if fragments[0].strip():
+                page_to_chunk_ids.setdefault(current_page, set()).add(current_chunk_global_id)
+                chunk_pages.add(current_page)
+
+            # Process new pages found within this sub_chunk.
+            for j in range(1, len(fragments), 2):
+                try:
+                    new_page = int(fragments[j]) + 1
+                    if fragments[j + 1].strip():
+                        page_to_chunk_ids.setdefault(new_page, set()).add(current_chunk_global_id)
+                        chunk_pages.add(new_page)
+                    current_page = new_page
+                except (IndexError, ValueError):
+                    continue
+
+            # Clean sub_chunk by removing page markers
+            clean_chunk = re.sub(page_pattern, '', sub_chunk).strip()
+
+            if c["heading"] == "Introduction":
+                continue
+
+            meta = {
+                "filename": markdown_file,
+                "mode": chunk_config.to_string(),
+                "char_len": len(clean_chunk),
+                "word_len": len(clean_chunk.split()),
+                "section": c['heading'],
+                "section_path": full_section_path,
+                "text_preview": clean_chunk[:100],
+                "page_numbers": sorted(list(chunk_pages)),
+                "chunk_id": current_chunk_global_id
+            }
+
+            if use_headings:
+                chunk_prefix = f"Description: {full_section_path} Content: "
+            else:
+                chunk_prefix = ""
+
+            new_chunks.append(chunk_prefix + clean_chunk)
+            new_sources.append(markdown_file)
+            new_metadata.append(meta)
+
+        total_chunks += len(sub_chunks)
+
+    # Embed new chunks
+    print(f"Embedding {len(new_chunks)} new chunks...")
+    embedder = SentenceTransformer(embedding_model_path)
+    new_embeddings = embedder.encode(new_chunks, batch_size=4, show_progress_bar=True)
+
+    # Add to FAISS index
+    faiss_index = faiss.read_index(str(faiss_index_path))
+    faiss_index.add(new_embeddings)
+    faiss.write_index(faiss_index, str(faiss_index_path))
+    print("Updated FAISS index.")
+
+    # Combine old and new artifacts
+    all_chunks = existing_chunks + new_chunks
+    all_sources = existing_sources + new_sources
+    all_metadata = existing_metadata + new_metadata
+
+    # Re-build BM25 index
+    print("Re-building BM25 index...")
+    tokenized_chunks = [preprocess_for_bm25(chunk) for chunk in all_chunks]
+    bm25_index = BM25Okapi(tokenized_chunks)
+    with open(bm25_index_path, "wb") as f:
+        pickle.dump(bm25_index, f)
+    print("Updated BM25 index.")
+
+    # Save updated artifacts
+    with open(chunks_path, "wb") as f:
+        pickle.dump(all_chunks, f)
+    with open(sources_path, "wb") as f:
+        pickle.dump(all_sources, f)
+    with open(meta_path, "wb") as f:
+        pickle.dump(all_metadata, f)
+
+    # Save updated page-to-chunk map
+    final_map = {str(page): sorted(list(id_set)) for page, id_set in page_to_chunk_ids.items()}
+    with open(map_path, "w") as f:
+        json.dump(final_map, f, indent=2)
+    print(f"Updated page to chunk ID map: {map_path}")
+
+    # Update index info
+    updated_chapters = sorted(list(set(existing_chapters + chapters_to_index)))
+    if target_textbook:
+        target_textbook["chapters"] = updated_chapters
+        target_textbook["status"] = "partial" if "all" not in updated_chapters else "full"
+    else:
+        index_info["textbooks"].append({
+            "markdown_file": markdown_file,
+            "chapters": updated_chapters,
+            "status": "partial" if "all" not in updated_chapters else "full"
+        })
+
+    with open(info_path, "w") as f:
+        json.dump(index_info, f, indent=2)
+
+    print(f"Successfully added {len(new_chunks)} new chunks for chapters {chapters_to_index}.")

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ from rich.markdown import Markdown
 from src.config import RAGConfig
 from src.generator import answer, double_answer, dedupe_generated_text
 from src.index_builder import build_index
+from src.index_updater import add_to_index
 from src.instrumentation.logging import get_logger
 from src.ranking.ranker import EnsembleRanker
 from src.preprocessing.chunking import DocumentChunker
@@ -32,9 +33,12 @@ ANSWER_NOT_FOUND = "I'm sorry, but I don't have enough information to answer tha
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Welcome to TokenSmith!")
-    parser.add_argument("mode", choices=["index", "chat"], help="operation mode")
+    parser.add_argument("mode", choices=["index", "chat", "add-chapters"], help="operation mode")
     parser.add_argument("--pdf_dir", default="data/chapters/", help="directory containing PDF files")
     parser.add_argument("--index_prefix", default="textbook_index", help="prefix for generated index files")
+    parser.add_argument("--partial", action="store_true",
+        help="use a partial index stored in 'index/partial_sections' instead of 'index/sections'"
+    )
     parser.add_argument("--model_path", help="path to generation model")
     parser.add_argument("--system_prompt_mode", choices=["baseline", "tutor", "concise", "detailed"], default="baseline")
     
@@ -42,6 +46,12 @@ def parse_args() -> argparse.Namespace:
     indexing_group.add_argument("--keep_tables", action="store_true")
     indexing_group.add_argument("--multiproc_indexing", action="store_true")
     indexing_group.add_argument("--embed_with_headings", action="store_true")
+    indexing_group.add_argument(
+        "--chapters",
+        nargs='+',
+        type=int,
+        help="a list of chapter numbers to index (e.g., --chapters 3 4 5)"
+    )
     parser.add_argument(
         "--double_prompt",
         action="store_true",
@@ -53,7 +63,7 @@ def parse_args() -> argparse.Namespace:
 def run_index_mode(args: argparse.Namespace, cfg: RAGConfig):
     strategy = cfg.get_chunk_strategy()
     chunker = DocumentChunker(strategy=strategy, keep_tables=args.keep_tables)
-    artifacts_dir = cfg.get_artifacts_directory()
+    artifacts_dir = cfg.get_artifacts_directory(partial=args.partial)
 
     data_dir = pathlib.Path("data")
     print(f"Looking for markdown files in {data_dir.resolve()}...")
@@ -75,11 +85,48 @@ def run_index_mode(args: argparse.Namespace, cfg: RAGConfig):
         index_prefix=args.index_prefix,
         use_multiprocessing=args.multiproc_indexing,
         use_headings=args.embed_with_headings,
+        chapters_to_index=args.chapters,
     )
-def use_indexed_chunks(question: str, chunks: list) -> list:
+
+def run_add_chapters_mode(args: argparse.Namespace, cfg: RAGConfig):
+    """Handles the logic for adding chapters to an existing index."""
+    if not args.chapters:
+        print("Please provide a list of chapters to add using the --chapters argument.")
+        return
+
+    strategy = cfg.get_chunk_strategy()
+    chunker = DocumentChunker(strategy=strategy, keep_tables=args.keep_tables)
+    artifacts_dir = cfg.get_artifacts_directory(partial=True)
+
+    data_dir = pathlib.Path("data")
+    print(f"Looking for markdown files in {data_dir.resolve()}...")
+    md_files = sorted(data_dir.glob("*.md"))
+    print(f"Found {len(md_files)} markdown files.")
+    print(f"First 5 markdown files: {[str(f) for f in md_files[:5]]}")
+
+    if not md_files:
+        print("ERROR: No markdown files found in data/.", file=sys.stderr)
+        sys.exit(1)
+
+    add_to_index(
+        markdown_file=str(md_files[0]),
+        chunker=chunker,
+        chunk_config=cfg.chunk_config,
+        embedding_model_path=cfg.embed_model,
+        embedding_model_context_window=cfg.embedding_model_context_window,
+        artifacts_dir=artifacts_dir,
+        index_prefix=args.index_prefix,
+        chapters_to_add=args.chapters,
+        use_headings=args.embed_with_headings,
+    )
+    print("Successfully added chapters to the index.")
+
+def use_indexed_chunks(question: str, chunks: list, cfg: RAGConfig, args: argparse.Namespace) -> list:
     # Logic for keyword matching from textbook index
     try:
-        with open('index/sections/textbook_index_page_to_chunk_map.json', 'r') as f:
+        artifacts_dir = cfg.get_artifacts_directory(partial=args.partial)
+        map_path = cfg.get_page_to_chunk_map_path(artifacts_dir, args.index_prefix)
+        with open(map_path, 'r') as f:
             page_to_chunk_map = json.load(f)
         with open('data/extracted_index.json', 'r') as f:
             extracted_index = json.load(f)
@@ -129,7 +176,7 @@ def get_answer(
         # No chunks - baseline mode
         ranked_chunks = []
     elif cfg.use_indexed_chunks:
-        ranked_chunks, topk_idxs = use_indexed_chunks(question, chunks)
+        ranked_chunks, topk_idxs = use_indexed_chunks(question, chunks, cfg, args)
     else:
         retrieval_query = question
         # print(f"Retrieval query: {retrieval_query}")
@@ -284,7 +331,8 @@ def run_chat_session(args: argparse.Namespace, cfg: RAGConfig):
 
     print("Initializing TokenSmith Chat...")
     try:
-        artifacts_dir = cfg.get_artifacts_directory()
+        artifacts_dir = cfg.get_artifacts_directory(partial=args.partial)
+        cfg.page_to_chunk_map_path = cfg.get_page_to_chunk_map_path(artifacts_dir, args.index_prefix)
         faiss_idx, bm25_idx, chunks, sources, meta = load_artifacts(artifacts_dir, args.index_prefix)
         print(f"Loaded {len(chunks)} chunks and {len(sources)} sources from artifacts.")
         retrievers = [FAISSRetriever(faiss_idx, cfg.embed_model), BM25Retriever(bm25_idx)]
@@ -362,6 +410,8 @@ def main():
         run_index_mode(args, cfg)
     elif args.mode == "chat":
         run_chat_session(args, cfg)
+    elif args.mode == "add-chapters":
+        run_add_chapters_mode(args, cfg)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR allows you to create partial indexes.
To build an index for specific chapters (e.g., Chapters 1 and 2), run
`python -m src.main index --chapters 1 2 --partial`
   * --chapters: Filters the source document to only include the specified chapter numbers.
   * --partial: Directs the application to use the index/partial_sections folder instead of the default index/sections.

If you already have an index and want to add more chapters to it:
`python -m src.main add-chapters --chapters 3 --partial`
This will append Chapter 3 to the index currently stored in the partial directory.

New makefile commands:
make run-index-partial: Creates a new partial index for specific chapters.
ex: `make run-index-partial CHAPTERS="1 2"`
make run-add-chapters-partial: Adds chapters to an existing partial index
make run-add-chapters-partial CHAPTERS="3"

To use the partial index:
python -m src.main chat --partial
make run-chat-partial