### PR TITLE
[DO NOT MERGE] Reference: Nomic 137M Embedding Engine Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ cd models
 
 Now, let's say config.yaml has following configs:
 ```yaml
-embed_model: "models/Qwen3-Embedding-4B-Q5_K_M.gguf"
+embed_model: models/nomic-embed-text-v1.5.f16.gguf
 model_path: "models/qwen2.5-1.5b-instruct-q5_k_m.gguf"
 ```
 For above config file, download appropriate files from the below link 
 and put them in the `models/` folder with the expected file name.
-- https://huggingface.co/Qwen/Qwen3-Embedding-4B-GGUF/tree/main
+- https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/tree/main
 - https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/tree/main
 
 ### 2) Build (creates env, builds llama.cpp, installs deps)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,4 @@
-embed_model: "models/Qwen3-Embedding-4B-Q5_K_M.gguf"
+embed_model: "models/nomic-embed-text-v1.5.f16.gguf"
 top_k: 10
 num_candidates: 50
 ensemble_method: "rrf"

--- a/environment.yml
+++ b/environment.yml
@@ -33,3 +33,4 @@ dependencies:
     - pydantic
     - docling
     - markdown
+    - gpt4all

--- a/src/index_builder.py
+++ b/src/index_builder.py
@@ -16,7 +16,9 @@ from typing import List, Dict
 
 import faiss
 from rank_bm25 import BM25Okapi
-from src.embedder import SentenceTransformer
+# from src.embedder import SentenceTransformer
+from gpt4all import Embed4All
+import numpy as np
 
 from src.preprocessing.chunking import DocumentChunker, ChunkConfig
 from src.preprocessing.extraction import extract_sections_from_markdown
@@ -176,30 +178,18 @@ def build_index(
 
     # Step 2: Create embeddings for FAISS index
     print(f"Embedding {len(all_chunks):,} chunks with {pathlib.Path(embedding_model_path).stem} ...")
-    embedder = SentenceTransformer(embedding_model_path)
-
-    if use_multiprocessing:
-        print("Starting multi-process pool for embeddings...")
-        # Start the pool. Adjust number of workers as needed.
-        pool = embedder.start_multi_process_pool(workers=4)
-        try:
-            # Compute embeddings in parallel
-            embeddings = embedder.encode_multi_process(
-                all_chunks, 
-                pool, 
-                batch_size=32
-            )
-        finally:
-            # Stop the pool to prevent hanging processes
-            embedder.stop_multi_process_pool(pool)
+    
+    model_name = os.path.basename(embedding_model_path)
+    model_dir = os.path.dirname(embedding_model_path)
+    if model_dir:
+        embedder = Embed4All(model_name, model_path=model_dir)
     else:
-        # Standard single-process embedding
-        embeddings = embedder.encode(
-            all_chunks, 
-            batch_size=8, 
-            show_progress_bar=True,
-            convert_to_numpy=True 
-        )
+        embedder = Embed4All(model_name)
+    
+    if use_multiprocessing:
+        print("Note: Python multiprocessing ignored. GPT4All uses native C++ hardware threading automatically.")
+    raw_embeddings = embedder.embed(all_chunks)
+    embeddings = np.array(raw_embeddings).astype('float32')
 
     # Step 3: Build FAISS index
     print(f"Building FAISS index for {len(all_chunks):,} chunks...")

--- a/src/index_builder.py
+++ b/src/index_builder.py
@@ -158,7 +158,7 @@ def build_index(
                     f"Content: "
                 )
             else:
-                chunk_prefix = ""
+                chunk_prefix = "search_document: "
 
             all_chunks.append(chunk_prefix+clean_chunk)
             sources.append(markdown_file)

--- a/src/main.py
+++ b/src/main.py
@@ -144,7 +144,10 @@ def get_answer(
         ordered, scores = ranker.rank(raw_scores=raw_scores)
         topk_idxs = filter_retrieved_chunks(cfg, chunks, ordered)
         ranked_chunks = [chunks[i] for i in topk_idxs]
-        
+
+        print(f"Top {len(ranked_chunks)} retrieved chunks:")
+        for rank, idx in enumerate(topk_idxs, 1):
+            print(f"Rank {rank}: Chunk ID {idx} - {chunks[idx][:100]}... (Score: {scores[rank-1]:.4f})")
         
         # Capture chunk info if in test mode
         if is_test_mode:

--- a/src/retriever.py
+++ b/src/retriever.py
@@ -17,7 +17,8 @@ from nltk.stem import WordNetLemmatizer
 
 import faiss
 import numpy as np
-from src.embedder import CachedEmbedder
+# from src.embedder import CachedEmbedder
+from gpt4all import Embed4All
 
 from src.config import RAGConfig
 from src.index_builder import preprocess_for_bm25
@@ -25,13 +26,13 @@ from src.index_builder import preprocess_for_bm25
 
 # -------------------------- Embedder cache ------------------------------
 
-_EMBED_CACHE: Dict[str, CachedEmbedder] = {}
+# _EMBED_CACHE: Dict[str, CachedEmbedder] = {}
 
-def _get_embedder(model_name: str) -> CachedEmbedder:
-    if model_name not in _EMBED_CACHE:
-        # Use the cached embedding model to avoid reloading it on every call
-        _EMBED_CACHE[model_name] = CachedEmbedder(model_name)
-    return _EMBED_CACHE[model_name]
+# def _get_embedder(model_name: str) -> CachedEmbedder:
+#     if model_name not in _EMBED_CACHE:
+#         # Use the cached embedding model to avoid reloading it on every call
+#         _EMBED_CACHE[model_name] = CachedEmbedder(model_name)
+#     return _EMBED_CACHE[model_name]
 
 
 # -------------------------- Read artifacts -------------------------------
@@ -91,7 +92,14 @@ class FAISSRetriever(Retriever):
 
     def __init__(self, index, embed_model: str):
         self.index = index
-        self.embedder = _get_embedder(embed_model)
+        # self.embedder = _get_embedder(embed_model)
+        model_name = os.path.basename(embed_model)
+        model_dir = os.path.dirname(embed_model)
+        
+        if model_dir:
+            self.embedder = Embed4All(model_name, model_path=model_dir)
+        else:
+            self.embedder = Embed4All(model_name)
 
     def get_scores(self,
                 query: str,
@@ -101,7 +109,8 @@ class FAISSRetriever(Retriever):
         Returns FAISS scores for top 'pool_size' keyed by global chunk index.
         """
         # FAISS expects a 2D array
-        q_vec = self.embedder.encode([query]).astype("float32")
+        query_raw = self.embedder.embed(query)
+        q_vec = np.array([query_raw]).astype("float32")
         
         # Safety check on vector dimensions
         if q_vec.shape[1] !=  self.index.d:

--- a/src/retriever.py
+++ b/src/retriever.py
@@ -109,7 +109,7 @@ class FAISSRetriever(Retriever):
         Returns FAISS scores for top 'pool_size' keyed by global chunk index.
         """
         # FAISS expects a 2D array
-        query_raw = self.embedder.embed(query)
+        query_raw = self.embedder.embed(f"search_query: {query}")
         q_vec = np.array([query_raw]).astype("float32")
         
         # Safety check on vector dimensions


### PR DESCRIPTION
## [DO NOT MERGE] REFERENCE ONLY
**This PR is for historical reference and documentation purposes only. It demonstrates the structural changes required to swap the 4B parameter baseline embedding model for a lightweight 137M parameter model.** TokenSmith's production environment will continue to use the Qwen 4B model to prioritize strict factual accuracy and semantic retrieval robustness over hardware efficiency.

---

## Context & Objective
This PR archives an architectural experiment aimed at reducing the memory footprint and FAISS indexing latency of the TokenSmith RAG pipeline. We evaluated replacing the baseline generalized embedding model with the highly specialized, retrieval-optimized `nomic-embed-text-v1.5.f16` model via the GPT4All SDK.

## Technical Implementation
To properly utilize Nomic's instruction-tuned architecture, this branch refactored the indexing and retrieval logic to support **Asymmetric Search**:
* **`src/index_builder.py`**: Injected the `search_document: ` prefix into the chunking pipeline before vector ingestion.
* **`src/retriever.py`**: Injected the `search_query: ` prefix into the FAISS retrieval query formulation to mathematically align the query vectors with the document vectors.
* **`config.yaml`**: Updated `embed_model` pathing to point to the Nomic 137M `.gguf` file.

## Benchmark Results & Trade-offs
We ran this branch against the 11-question Golden Dataset (`benchmarks.yaml`) with the following empirical findings:

**The Pros (Efficiency gains):**
* **Memory Optimization:** Reduced the embedding engine RAM footprint by roughly 10x.
* **Indexing Latency:** Slashed textbook FAISS indexing time from >24 hours down to ~4 minutes.
* **Focused Accuracy:** Successfully retained Rank 1 retrieval accuracy on highly targeted, conceptual queries (e.g., SQL Aggregation with Grouping).

**The Cons (Why this is not being merged):**
* **Vector Dilution:** The 137M model failed to compress multi-part, complex queries (e.g., the B+ Tree search/insert/delete mechanisms) into a single 768-dimensional vector without losing semantic focus.
* **Semantic Distractors:** The lightweight model lacked the generalized reasoning to distinguish between academic standards and real-world implementations, incorrectly retrieving Oracle's "Read committed" default instead of the SQL Standard's "Serializable" default.

## Prerequisites for Future Implementation
If hardware constraints eventually force a migration to this lightweight model, the following architectural safety nets must be fully implemented and tuned prior to merging:
1. **Hypothetical Document Embeddings (HyDE):** To generate semantic targets before embedding the user query.
2. **Query Decomposition:** To split multi-part questions into distinct, focused vector searches to prevent dilution.