### PR TITLE
Add flash attention with cross session caching

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -1,5 +1,5 @@
 import textwrap, re
-from llama_cpp import Llama
+from llama_cpp import Llama, LlamaRAMCache
 
 ANSWER_START = "<<<ANSWER>>>"
 ANSWER_END   = "<<<END>>>"
@@ -116,12 +116,16 @@ def get_llama_model(model_path: str, n_ctx: int = 4096):
             _LLM_CACHE[model_path] = Llama(model_path=model_path,
                                        n_ctx=n_ctx,
                                        verbose=False,
-                                       n_gpu_layers=-1)
+                                       n_gpu_layers=-1,
+                                       flash_attn=True)
         except Exception as e:
             print(f"Error loading LLaMA model from {model_path} on GPU: {e}")
             _LLM_CACHE[model_path] = Llama(model_path=model_path,
                                        n_ctx=n_ctx,
                                        verbose=False)
+
+        cache = LlamaRAMCache()
+        _LLM_CACHE[model_path].set_cache(cache)
     return _LLM_CACHE[model_path]
 
 def stream_llama_cpp(prompt: str, model_path: str, max_tokens: int, temperature: float):


### PR DESCRIPTION
Flash Attention is a drop-in enhancement over regular attention. Also caching the tokens in memory for reuse across multiple generation sessions. The caching provides speed-up for both CPU and GPU generations.

On my local device testing, adding these provided a significant speed-up:
```
with
%%% Time taken: 74.35267187000045 seconds %%%
%%% Time taken: 76.19330428800004 seconds %%%
%%% Time taken: 72.47534711900153 seconds %%%

without
%%% Time taken: 99.0271961060007 seconds %%%
%%% Time taken: 88.47190304200012 seconds %%%
%%% Time taken: 141.32913875799932 seconds %%%
```

These timings have been calculated from the start of the loop until the end of the loop. So that the `contextual_query` generation is also captured.