### PR TITLE
[BREAKING PR]Support generator model selection from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,18 @@ git clone https://github.com/georgia-tech-db/TokenSmith.git
 cd TokenSmith
 ```
 
-Create the model directory and put in the appropriate models in it.
+Create the model directories and put in the appropriate models in them.
 ```shell
-mkdir models
-cd models
+mkdir -p models/generators models/embedders
 ```
 
 Now, let's say config.yaml has following configs:
 ```yaml
-embed_model: "models/Qwen3-Embedding-4B-Q5_K_M.gguf"
-model_path: "models/qwen2.5-1.5b-instruct-q5_k_m.gguf"
+embed_model: "models/embedders/Qwen3-Embedding-4B-Q5_K_M.gguf"
+model_path: "models/generators/qwen2.5-1.5b-instruct-q5_k_m.gguf"
 ```
 For above config file, download appropriate files from the below link 
-and put them in the `models/` folder with the expected file name.
+and put them in the `models/embedders/` and `models/generators/` folders with the expected file name.
 - https://huggingface.co/Qwen/Qwen3-Embedding-4B-GGUF/tree/main
 - https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/tree/main
 
@@ -131,14 +130,14 @@ Priority (highest → lowest):
 ### Example
 
 ```yaml
-embed_model: "sentence-transformers/all-MiniLM-L6-v2"
+embed_model: "models/embedders/all-MiniLM-L6-v2"
 top_k: 5
 max_gen_tokens: 400
 halo_mode: "none"
 seg_filter: null
 
 # Model settings
-model_path: "models/qwen2.5-0.5b-instruct-q5_k_m.gguf"
+model_path: "models/generators/qwen2.5-0.5b-instruct-q5_k_m.gguf"
 
 # Indexing settings
 chunk_mode: "tokens" # or "chars"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,6 @@
-embed_model: "models/Qwen3-Embedding-4B-Q5_K_M.gguf"
+embed_model: "models/embedders/Qwen3-Embedding-4B-Q5_K_M.gguf"
 embedding_model_context_window: 4096
+
 top_k: 10
 num_candidates: 50
 ensemble_method: "rrf"
@@ -7,7 +8,7 @@ ranker_weights: {"faiss":1,"bm25":0,"index_keywords":0}
 rrf_k: 60
 max_gen_tokens: 400
 chunk_mode: "recursive_sections"
-gen_model: "models/qwen2.5-3b-instruct-q8_0.gguf"
+gen_model: "models/generators/qwen2.5-3b-instruct-q8_0.gguf"
 chunk_size_in_chars: 2000
 chunk_overlap: 300
 use_hyde: false

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -67,6 +67,7 @@ class ChatRequest(BaseModel):
     temperature: Optional[float] = None
     top_k: Optional[int] = None  # Alternative name for max_chunks, takes precedence if both provided
     session_id: Optional[str] = None
+    gen_model: Optional[str] = None  # Optional generator model override (must exist under models/generators/)
 
 
 class FeedbackRequest(BaseModel):
@@ -102,6 +103,28 @@ def _ensure_initialized():
             status_code=503,
             detail="Artifacts not loaded. Please run indexing first."
         )
+
+def _get_available_gen_models() -> List[str]:
+    """Return generator model paths derived from the local models/generators/ directory."""
+    models_dir = _project_root / "models" / "generators"
+    if not models_dir.exists():
+        return []
+    return sorted(
+        str(pathlib.Path("models") / "generators" / p.name)
+        for p in models_dir.iterdir()
+        if p.is_file() and p.suffix == ".gguf"
+    )
+
+def _resolve_gen_model(requested_model: Optional[str]) -> str:
+    """Pick generator model, validating membership if an override is provided."""
+    if not _config or not _config.gen_model:
+        raise HTTPException(status_code=500, detail="Model path not configured.")
+    if not requested_model:
+        return _config.gen_model
+    available = _get_available_gen_models()
+    if requested_model not in available:
+        raise HTTPException(status_code=400, detail="Unknown generator model.")
+    return requested_model
 
 def _create_log(chunks , sources , topk_idxs, ordered_ranked_scores, page_nums, full_response_accumulator, request,
                  enable_chunks, prompt_type, max_chunks, temperature):
@@ -296,6 +319,14 @@ async def feedback(request: FeedbackRequest):
         return FeedbackResponse(ok=True, message="Feedback stored; unknown answer_id.")
     return FeedbackResponse(ok=True, message="Feedback stored; topic extractor disabled.")
 
+@app.get("/api/models/generators")
+async def list_generator_models():
+    """List available generator models from the local models/ directory."""
+    _ensure_initialized()
+    return {
+        "available": _get_available_gen_models(),
+        "default": _config.gen_model if _config else None,
+    }
 
 @app.post("/api/test-chat")
 async def test_chat(request: ChatRequest):
@@ -385,8 +416,7 @@ async def chat_stream(request: ChatRequest):
         topk_idxs = [int(i) for i in topk_idxs]
         ranked_chunks = [chunks[i] for i in topk_idxs[:max_chunks]]
     
-    if not _config.gen_model:
-        raise HTTPException(status_code=500, detail="Model path not configured.")
+    model_path = _resolve_gen_model(request.gen_model)
 
     answer_id = str(uuid4())
     session_id = request.session_id or str(uuid4())
@@ -411,7 +441,7 @@ async def chat_stream(request: ChatRequest):
             yield f"data: {json.dumps({'type': 'chunks_by_page', 'content': chunks_by_page})}\n\n"
 
             # Stream generation token by token
-            for delta in answer(request.query, ranked_chunks, _config.gen_model,
+            for delta in answer(request.query, ranked_chunks, model_path,
                               _config.max_gen_tokens, system_prompt_mode=prompt_type, temperature=temperature):
                 if delta:
                     full_response_accumulator.append(delta) # Capture for log
@@ -523,8 +553,7 @@ async def chat(request: ChatRequest):
 
             ranked_chunks = [chunks[i] for i in topk_idxs[:max_chunks]]
 
-        if not _config.gen_model:
-            raise HTTPException(status_code=500, detail="Model path not configured.")
+        model_path = _resolve_gen_model(request.gen_model)
 
         # 3. Full Generation
         try:
@@ -532,7 +561,7 @@ async def chat(request: ChatRequest):
                 answer(
                     request.query,
                     ranked_chunks,
-                    _config.gen_model,
+                    model_path,
                     _config.max_gen_tokens,
                     system_prompt_mode=prompt_type,
                     temperature=temperature,

--- a/src/config.py
+++ b/src/config.py
@@ -20,7 +20,7 @@ class RAGConfig:
     # retrieval + ranking
     top_k: int = 10
     num_candidates: int = 60
-    embed_model: str = "models/Qwen3-Embedding-4B-Q5_K_M.gguf"
+    embed_model: str = "models/embedders/Qwen3-Embedding-4B-Q5_K_M.gguf"
     embedding_model_context_window: int = 4096
     ensemble_method: str = "rrf"
     rrf_k: int = 60
@@ -32,8 +32,8 @@ class RAGConfig:
 
     # generation
     max_gen_tokens: int = 400
-    gen_model: str = "models/qwen2.5-3b-instruct-q8_0.gguf"
-
+    gen_model: str = "models/generators/qwen2.5-3b-instruct-q8_0.gguf"
+    
     # testing
     system_prompt_mode: str = "baseline"
     disable_chunks: bool = False

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,7 +57,7 @@ pytest tests/ --output-mode=html
 
 ```yaml
 # Embedding Configuration
-embed_model: "/path/to/Qwen3-Embedding-4B-Q8_0.gguf"
+embed_model: "/path/to/models/embedders/Qwen3-Embedding-4B-Q8_0.gguf"
 
 # Retrieval Configuration
 top_k: 5
@@ -69,7 +69,7 @@ ranker_weights:
 rrf_k: 60
 
 # Generator Configuration
-model_path: "models/qwen2.5-0.5b-instruct-q5_k_m.gguf"
+model_path: "models/generators/qwen2.5-0.5b-instruct-q5_k_m.gguf"
 max_gen_tokens: 400
 system_prompt_mode: "tutor"  # Options: baseline, tutor, concise, detailed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,8 +161,8 @@ def config(pytestconfig):
         "output_mode": pytestconfig.getoption("--output-mode") or cfg.get("output_mode", "terminal"),
         
         # Models
-        "model_path": pytestconfig.getoption("--model-path") or cfg.get("model_path", "models/qwen2.5-3b-instruct-q8_0.gguf"),
-        "embed_model": pytestconfig.getoption("--embed-model") or cfg.get("embed_model", os.path.join(Path(__file__).parent.parent, "models", "Qwen3-Embedding-4B-Q8_0.gguf")),
+        "model_path": pytestconfig.getoption("--model-path") or cfg.get("model_path", "models/generators/qwen2.5-3b-instruct-q8_0.gguf"),
+        "embed_model": pytestconfig.getoption("--embed-model") or cfg.get("embed_model", os.path.join(Path(__file__).parent.parent, "models", "embedders", "Qwen3-Embedding-4B-Q8_0.gguf")),
         
         # Generator
         "system_prompt_mode": pytestconfig.getoption("--system-prompt") or cfg.get("system_prompt_mode", "baseline"),


### PR DESCRIPTION
### [BREAKING PR: REQUIRES FOLLOWING LOCAL SETUP CHANGES]
- Create `models/generators` and `models/embedders` instead of just `models`.
- Add respective generator and embedder models under appropriate directory.
- The PR changes default paths in configs, make sure to verify them for your model.

## Summary
- Bifurcates `models` directory into `models/generators` and `models/embedders` **(All developers expected to make these changes locally for smooth execution once PR lands)**
- Add generator model discovery from `models/generators` and expose it via a new API endpoint
- Allow per-request generator model override with validation
- Updates config/test/docs paths to reflect split `models/generators` and `models/embedders`

## Changes
- New `GET /api/models/generators` endpoint
- `gen_model` override supported in chat and stream requests
- Defaults updated to `models/generators` and `models/embedders`
- README and test config examples updated to accommodate `models/generators` and `models/embedders`

## Test Plan
- [x] Manual: call `GET /api/models/generators`
- [x] Manual: send `gen_model` in `/api/chat/stream` and verify it uses the selected model