### PR TITLE
[HIGH PRIORITY FIX] revert back to sequential encoding for index creation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,14 +1,15 @@
 embed_model: "models/Qwen3-Embedding-4B-Q5_K_M.gguf"
+embedding_model_context_window: 4096
 top_k: 10
 num_candidates: 50
 ensemble_method: "rrf"
-ranker_weights: {"faiss":1,"bm25":0,"index_keywords":0}
+ranker_weights: {"faiss":0.75,"bm25":0.25,"index_keywords":0}
 rrf_k: 60
 max_gen_tokens: 400
-chunk_mode : "recursive_sections"
+chunk_mode: "recursive_sections"
 gen_model: "models/qwen2.5-3b-instruct-q8_0.gguf"
-chunk_size: 2000
-chunk_overlap: 200
+chunk_size_in_chars: 2000
+chunk_overlap: 300
 use_hyde: false
 hyde_max_tokens: 300
 use_indexed_chunks: false
@@ -17,4 +18,4 @@ rerank_top_k: 5
 use_double_prompt: false
 enable_history: true
 max_history_turns: 3
-enable_topic_extraction: true
+enable_topic_extraction: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ embedding_model_context_window: 4096
 top_k: 10
 num_candidates: 50
 ensemble_method: "rrf"
-ranker_weights: {"faiss":0.75,"bm25":0.25,"index_keywords":0}
+ranker_weights: {"faiss":1,"bm25":0,"index_keywords":0}
 rrf_k: 60
 max_gen_tokens: 400
 chunk_mode: "recursive_sections"

--- a/src/config.py
+++ b/src/config.py
@@ -14,15 +14,16 @@ class RAGConfig:
     # chunking
     chunk_config: ChunkConfig = field(init=False)
     chunk_mode: str = "recursive_sections"
-    chunk_size: int = 2000
-    chunk_overlap: int = 200
+    chunk_size_in_chars: int = 2000
+    chunk_overlap: int = 300
 
     # retrieval + ranking
     top_k: int = 10
     num_candidates: int = 60
     embed_model: str = "models/Qwen3-Embedding-4B-Q5_K_M.gguf"
+    embedding_model_context_window: int = 4096
     ensemble_method: str = "rrf"
-    rrf_k: int  = 60
+    rrf_k: int = 60
     ranker_weights: Dict[str, float] = field(
         default_factory=lambda: {"faiss": 1.0, "bm25": 0.0, "index_keywords": 0.0}
     )
@@ -32,7 +33,7 @@ class RAGConfig:
     # generation
     max_gen_tokens: int = 400
     gen_model: str = "models/qwen2.5-3b-instruct-q8_0.gguf"
-    
+
     # testing
     system_prompt_mode: str = "baseline"
     disable_chunks: bool = False
@@ -48,7 +49,7 @@ class RAGConfig:
     # conversational memory
     enable_history: bool = True
     max_history_turns: int = 3
-    
+
     # index parameters
     use_indexed_chunks: bool = False
     extracted_index_path: os.PathLike = "data/extracted_index.json"
@@ -61,17 +62,18 @@ class RAGConfig:
     @classmethod
     def from_yaml(cls, path: os.PathLike) -> RAGConfig:
         with open(path, 'r') as f:
-            data = yaml.safe_load(open(path))
+            data = yaml.safe_load(f)
         return cls(**data)
-    
+
     def __post_init__(self):
         """Validation logic runs automatically after initialization."""
         assert self.top_k > 0, "top_k must be > 0"
         assert self.num_candidates >= self.top_k, "num_candidates must be >= top_k"
-        assert self.ensemble_method.lower() in {"linear","weighted","rrf"}
-        if self.ensemble_method.lower() in {"linear","weighted"}:
+        assert self.ensemble_method.lower() in {"linear", "weighted", "rrf"}
+        assert self.embedding_model_context_window > 0, "embedding_model_context_window must be > 0"
+        if self.ensemble_method.lower() in {"linear", "weighted"}:
             s = sum(self.ranker_weights.values()) or 1.0
-            self.ranker_weights = {k: v/s for k, v in self.ranker_weights.items()}
+            self.ranker_weights = {k: v / s for k, v in self.ranker_weights.items()}
         self.chunk_config = self.get_chunk_config()
         self.chunk_config.validate()
 
@@ -81,8 +83,8 @@ class RAGConfig:
         """Parse chunk configuration from YAML."""
         if self.chunk_mode == "recursive_sections":
             return SectionRecursiveConfig(
-                recursive_chunk_size=self.chunk_size,
-                recursive_overlap=self.chunk_overlap
+                recursive_chunk_size=self.chunk_size_in_chars,
+                recursive_overlap=self.chunk_overlap,
             )
         else:
             raise ValueError(f"Unknown chunk_mode: {self.chunk_mode}. Supported: recursive_sections")
@@ -98,14 +100,12 @@ class RAGConfig:
         strategy_dir = pathlib.Path("index", strategy.artifact_folder_name())
         strategy_dir.mkdir(parents=True, exist_ok=True)
         return strategy_dir
-    
-    def get_config_state(self) -> None:
-        """Returns dict of all config parameters except chunk_config """
+
+    def get_config_state(self) -> dict:
+        """Returns dict of all config parameters except chunk_config."""
         state = self.__dict__.copy()
-        state.pop("chunk_config", None) # remove chunk_config to avoid serialization issues
-        # also pop any non-serializable fields if needed
+        state.pop("chunk_config", None)
         for key in list(state.keys()):
             if not isinstance(state[key], (int, float, str, bool, list, dict, type(None))):
                 state.pop(key)
         return state
-        

--- a/src/embedder.py
+++ b/src/embedder.py
@@ -12,10 +12,9 @@ from tqdm import tqdm
 _worker_model: Optional[Llama] = None
 _worker_embedding_dim: int = 0
 
+
 def _init_worker(model_path: str, n_ctx: int, n_threads: int):
-    """
-    Initializes the model inside a worker process.
-    """
+    """Initializes the model inside a worker process."""
     global _worker_model, _worker_embedding_dim
 
     _worker_model = Llama(
@@ -24,57 +23,55 @@ def _init_worker(model_path: str, n_ctx: int, n_threads: int):
         n_threads=n_threads,
         embedding=True,
         verbose=False,
-        use_mmap=True # Allows OS to share model weights across processes
+        use_mmap=True,
     )
-    
-    # Cache dimension
+
     test_emb = _worker_model.create_embedding("test")['data'][0]['embedding']
     _worker_embedding_dim = len(test_emb)
 
+
 def _encode_batch_worker(texts: List[str]) -> List[List[float]]:
-    """
-    Encodes a batch of text using the worker's local model instance.
-    """
+    """Encodes a batch of text using the worker's local model instance."""
     global _worker_model, _worker_embedding_dim
     if _worker_model is None:
         return []
-        
+
     embeddings = []
     for text in texts:
         try:
-            # Create embedding
             emb = _worker_model.create_embedding(text)['data'][0]['embedding']
             embeddings.append(emb)
         except Exception:
-            # Return zero vector on failure
             embeddings.append([0.0] * _worker_embedding_dim)
-            
+
     return embeddings
+
 
 class SentenceTransformer:
     def __init__(self, model_path: str, n_ctx: int = 4096, n_threads: int = None):
         """
         Initialize with a local GGUF model file path.
-        
+
         Args:
             model_path: Path to your local .gguf file
-            n_ctx: Context window size (increased to match Qwen3 training context)
-            n_threads: Number of threads to use (None = auto-detect)
+            n_ctx:      Context window size. Defaults to 4096.
+            n_threads:  Number of threads (None = auto-detect)
         """
         self.model_path = model_path
         self.n_ctx = n_ctx
-        
+
         self.model = Llama(
             model_path=model_path,
             n_ctx=n_ctx,
             n_threads=n_threads,
             embedding=True,
-            verbose=True,
+            verbose=False,
             use_mmap=True,
-            n_gpu_layers=-1 # use GPU if available
+            n_gpu_layers=-1,
         )
         self._embedding_dimension = None
-        
+
+        # Warm up — also caches embedding dimension
         _ = self.embedding_dimension
 
     @property
@@ -85,116 +82,102 @@ class SentenceTransformer:
             self._embedding_dimension = len(test_embedding)
         return self._embedding_dimension
 
-    def encode(self, 
-           texts: Union[str, List[str]], 
-           batch_size: int = 16,  # Adjusted for 4B model
-           normalize: bool = False,
-           show_progress_bar: bool = False,
-           **kwargs) -> np.ndarray:
-
+    def encode(
+        self,
+        texts: Union[str, List[str]],
+        batch_size: int = 1,
+        normalize: bool = False,
+        show_progress_bar: bool = False,
+        **kwargs,
+    ) -> np.ndarray:
         """
-        Encode texts to embeddings with batch processing.
-        
+        Encode texts to embeddings sequentially.
+
         Args:
-            texts: Single text or list of texts to encode
-            batch_size: Number of texts to process at once
-            normalize: Whether to normalize embeddings
-            show_progress_bar: Whether to show progress bar
-            Returns:
-            numpy.ndarray: Float32 embeddings array
+            texts:             Single text or list of texts to encode.
+            batch_size:        Unused — kept for API compatibility only.
+                               All encoding is sequential (one chunk per
+                               forward pass) due to llama-cpp-python
+                               n_seq_max limitations in 0.3.x.
+            normalize:         Whether to L2-normalize embeddings.
+            show_progress_bar: Whether to show a tqdm progress bar.
+        Returns:
+            numpy.ndarray: Float32 embeddings of shape (len(texts), dim).
         """
         if isinstance(texts, str):
             texts = [texts]
-            
-        if not texts:
-            return np.array([], dtype=np.float32).reshape(0, -1)
-        
-        # Process in batches
-        embeddings = []
-        num_batches = (len(texts) + batch_size - 1) // batch_size
 
-        for i in tqdm(range(num_batches), desc="Encoding", disable=not show_progress_bar):
-            start_idx = i * batch_size
-            end_idx = min((i + 1) * batch_size, len(texts))
-            batch_texts = texts[start_idx:end_idx]
-            
+        if not texts:
+            return np.array([], dtype=np.float32).reshape(0, self.embedding_dimension)
+
+        embeddings = []
+        failed_indices = []
+
+        for i, text in enumerate(tqdm(texts, desc="Encoding", disable=not show_progress_bar)):
             try:
-                # IMPORTANT CHANGE: Pass the entire LIST to the model at once.
-                # This triggers the native C++/Metal batch processing logic.
-                response = self.model.create_embedding(batch_texts)
-                
-                # Extract the list of embedding vectors from the response
-                batch_embeddings = [item['embedding'] for item in response['data']]
-                embeddings.extend(batch_embeddings)
-                
+                emb = self.model.create_embedding(text)['data'][0]['embedding']
+                embeddings.append(emb)
             except Exception as e:
-                print(f"Error encoding batch: {e}")
-                # Fallback: encode one by one if batch fails, or append zeros
-                for _ in batch_texts:
-                    embeddings.append([0.0] * self.embedding_dimension)
-                
+                print(f"  [ERROR] Failed to embed chunk {i}: {e}")
+                print(f"  Preview: '{text[:80]}...'")
+                failed_indices.append(i)
+                embeddings.append([0.0] * self.embedding_dimension)
+
+        if failed_indices:
+            print(f"\n[WARNING] {len(failed_indices)} chunk(s) failed embedding: indices {failed_indices}")
+            print("These chunks will have zero vectors in the FAISS index and will not be retrievable.\n")
+
         vecs = np.array(embeddings, dtype=np.float32)
-        
-        if normalize: # do L2 normalization
+
+        if normalize:
             norms = np.linalg.norm(vecs, axis=1, keepdims=True)
             vecs = vecs / np.where(norms == 0, 1e-12, norms)
-            
+
         return vecs
 
     def get_sentence_embedding_dimension(self) -> int:
-        """Get the dimension of embeddings (compatibility method)."""
+        """Compatibility method."""
         return self.embedding_dimension
 
     def start_multi_process_pool(self, num_workers: int = None) -> multiprocessing.pool.Pool:
-        """
-        Starts a pool of worker processes.
-        """
-        if num_workers:
-            workers = num_workers
-        else:
-            # Default to CPU count - 2 (leave room for OS/Main process)
-            workers = max(1, multiprocessing.cpu_count() - 2)
-
+        """Starts a pool of worker processes."""
+        workers = num_workers if num_workers else max(1, multiprocessing.cpu_count() - 2)
         print(f"Creating {workers} worker processes...")
-        
-        # Use 1 thread per worker to avoid CPU thrashing
-        worker_threads = 1
-        
+
         pool = multiprocessing.Pool(
             processes=workers,
             initializer=_init_worker,
-            initargs=(self.model_path, self.n_ctx, worker_threads)
+            initargs=(self.model_path, self.n_ctx, 1),
         )
         return pool
 
-    def encode_multi_process(self, texts: List[str], pool: multiprocessing.pool.Pool, batch_size: int = 32) -> np.ndarray:
-        """
-        Distributes work across the pool.
-        """
-        # Sort by length to minimize padding/processing waste
+    def encode_multi_process(
+        self,
+        texts: List[str],
+        pool: multiprocessing.pool.Pool,
+        batch_size: int = 32,
+    ) -> np.ndarray:
+        """Distributes encoding work across the worker pool."""
         indices = np.argsort([len(t) for t in texts])[::-1]
         sorted_texts = [texts[i] for i in indices]
 
-        # Create batches
-        chunks = [sorted_texts[i : i + batch_size] for i in range(0, len(sorted_texts), batch_size)]
+        chunks = [sorted_texts[i:i + batch_size] for i in range(0, len(sorted_texts), batch_size)]
 
-        # Process with progress bar
         results = []
         print(f"Dispatching {len(chunks)} batches to pool...")
         for batch_result in tqdm(
-            pool.imap(_encode_batch_worker, chunks), 
-            total=len(chunks), 
-            desc="Parallel Encoding"
+            pool.imap(_encode_batch_worker, chunks),
+            total=len(chunks),
+            desc="Parallel Encoding",
         ):
             results.append(batch_result)
 
         flat_embeddings = [emb for batch in results for emb in batch]
 
-        # Restore original order
         inverse_indices = np.empty_like(indices)
         inverse_indices[indices] = np.arange(len(indices))
         ordered_embeddings = [flat_embeddings[i] for i in inverse_indices]
-        
+
         return np.array(ordered_embeddings, dtype=np.float32)
 
     @staticmethod
@@ -205,14 +188,13 @@ class SentenceTransformer:
 
 class EmbeddingCache:
     """Persistent SQLite cache for embeddings."""
-    
+
     def __init__(self, cache_dir: str = "index/cache"):
         self.db_path = Path(cache_dir) / "embeddings.db"
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
-    
+
     def _init_db(self):
-        """Initialize database schema."""
         with sqlite3.connect(self.db_path) as conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS embeddings (
@@ -225,31 +207,27 @@ class EmbeddingCache:
                 )
             """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_model_name ON embeddings(model_name)")
-    
+
     def get(self, model_path: str, query: str) -> Optional[np.ndarray]:
-        """Retrieve cached embedding if it exists."""
         model_hash = hashlib.md5(model_path.encode()).hexdigest()[:16]
-        
         with sqlite3.connect(self.db_path) as conn:
             row = conn.execute(
                 "SELECT embedding FROM embeddings WHERE model_hash=? AND query_text=?",
-                (model_hash, query)
+                (model_hash, query),
             ).fetchone()
-            
             if row:
                 return np.frombuffer(row[0], dtype=np.float32)
         return None
-    
+
     def set(self, model_path: str, query: str, embedding: np.ndarray):
-        """Store embedding in cache."""
         model_name = Path(model_path).stem
         model_hash = hashlib.md5(model_path.encode()).hexdigest()[:16]
         blob = embedding.astype(np.float32).tobytes()
-        
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
-                "INSERT OR REPLACE INTO embeddings (model_name, model_hash, query_text, embedding) VALUES (?,?,?,?)",
-                (model_name, model_hash, query, blob)
+                "INSERT OR REPLACE INTO embeddings "
+                "(model_name, model_hash, query_text, embedding) VALUES (?,?,?,?)",
+                (model_name, model_hash, query, blob),
             )
 
 
@@ -258,22 +236,20 @@ class CachedEmbedder:
     Wrapper around SentenceTransformer that caches query embeddings.
     Drop-in replacement for SentenceTransformer.
     """
-    
+
     def __init__(self, model_path: str, **kwargs):
         self.embedder = SentenceTransformer(model_path, **kwargs)
         self.cache = EmbeddingCache()
         self.model_path = model_path
-    
+
     def encode(self, texts, **kwargs):
-        """Encode texts with caching support."""
         if isinstance(texts, str):
             texts = [texts]
-        
+
         results = []
         to_compute = []
         to_compute_indices = []
-        
-        # Check cache for each text
+
         for i, text in enumerate(texts):
             cached = self.cache.get(self.model_path, text)
             if cached is not None:
@@ -281,18 +257,15 @@ class CachedEmbedder:
             else:
                 to_compute.append(text)
                 to_compute_indices.append(i)
-        
-        # Compute missing embeddings
+
         if to_compute:
             computed = self.embedder.encode(to_compute, **kwargs)
             for idx, text, emb in zip(to_compute_indices, to_compute, computed):
                 self.cache.set(self.model_path, text, emb)
                 results.append((idx, emb))
-        
-        # Restore original order
+
         results.sort(key=lambda x: x[0])
         return np.array([emb for _, emb in results])
-    
+
     def __getattr__(self, name):
-        """Delegate other methods to wrapped embedder."""
         return getattr(self.embedder, name)

--- a/src/index_builder.py
+++ b/src/index_builder.py
@@ -2,9 +2,6 @@
 """
 index_builder.py
 PDF -> markdown text -> chunks -> embeddings -> BM25 + FAISS + metadata
-
-Entry point (called by main.py):
-    build_index(markdown_file, cfg, keep_tables=True, do_visualize=False)
 """
 
 import os
@@ -14,11 +11,12 @@ import re
 import json
 from typing import List, Dict
 
+import numpy as np
 import faiss
 from rank_bm25 import BM25Okapi
 from src.embedder import SentenceTransformer
 
-from src.preprocessing.chunking import DocumentChunker, ChunkConfig
+from src.preprocessing.chunking import DocumentChunker, ChunkConfig, print_chunk_stats
 from src.preprocessing.extraction import extract_sections_from_markdown
 
 # ----- runtime parallelism knobs (avoid oversubscription) -----
@@ -29,10 +27,8 @@ os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
 
-# Default keywords to exclude sections
 DEFAULT_EXCLUSION_KEYWORDS = ['questions', 'exercises', 'summary', 'references']
 
-# ------------------------ Main index builder -----------------------------
 
 def build_index(
     markdown_file: str,
@@ -40,10 +36,11 @@ def build_index(
     chunker: DocumentChunker,
     chunk_config: ChunkConfig,
     embedding_model_path: str,
+    embedding_model_context_window: int,
     artifacts_dir: os.PathLike,
     index_prefix: str,
     use_multiprocessing: bool = False,
-    use_headings: bool = False
+    use_headings: bool = False,
 ) -> None:
     """
     Extract sections, chunk, embed, and build both FAISS and BM25 indexes.
@@ -54,12 +51,12 @@ def build_index(
         - {prefix}_chunks.pkl
         - {prefix}_sources.pkl
         - {prefix}_meta.pkl
+        - {prefix}_page_to_chunk_map.json
     """
     all_chunks: List[str] = []
     sources: List[str] = []
     metadata: List[Dict] = []
 
-    # Extract sections from markdown. Exclude some with certain keywords.
     sections = extract_sections_from_markdown(
         markdown_file,
         exclusion_keywords=DEFAULT_EXCLUSION_KEYWORDS
@@ -70,73 +67,47 @@ def build_index(
     total_chunks = 0
     heading_stack = []
 
-    # Step 1: Chunk using DocumentChunker
+    # Step 1: Chunk
     for i, c in enumerate(sections):
-        # Determine current section level
         current_level = c.get('level', 1)
-
-        # Determine current chapter number
         chapter_num = c.get('chapter', 0)
 
-        # Pop sections that are deeper or siblings
         while heading_stack and heading_stack[-1][0] >= current_level:
             heading_stack.pop()
-        
-        # Push pair of (level, heading)
+
         if c['heading'] != "Introduction":
             heading_stack.append((current_level, c['heading']))
 
-        # Construct section path
         path_list = [h[1] for h in heading_stack]
         full_section_path = " ".join(path_list)
         full_section_path = f"Chapter {chapter_num} " + full_section_path
 
-        # Use DocumentChunker to recursively split this section
         sub_chunks = chunker.chunk(c['content'])
-
-        # Regex to find page markers like "--- Page 3 ---"
         page_pattern = re.compile(r'--- Page (\d+) ---')
 
-        # Iterate through each chunk produced from this section
         for sub_chunk_id, sub_chunk in enumerate(sub_chunks):
-            # Track all pages this specific chunk touches
             chunk_pages = set()
-
-            # Split the sub_chunk by page markers to see if it
-            # spans multiple pages.
             fragments = page_pattern.split(sub_chunk)
 
-            # If there is content before the first page marker,
-            # it belongs to the current_page.
             if fragments[0].strip():
-                page_to_chunk_ids.setdefault(current_page, set()).add(total_chunks+sub_chunk_id)
+                page_to_chunk_ids.setdefault(current_page, set()).add(total_chunks + sub_chunk_id)
                 chunk_pages.add(current_page)
 
-            # Process the new pages found within this sub_chunk. 
-            # Step by 2 where each pair represents (page number, text after it)
-            for i in range(1, len(fragments), 2):
+            for idx in range(1, len(fragments), 2):
                 try:
-                    # Get the new page number from the marker
-                    new_page = int(fragments[i]) + 1
-
-                    # If there is text after this marker, it belongs to the new_page.
-                    if fragments[i+1].strip():
+                    new_page = int(fragments[idx]) + 1
+                    if fragments[idx + 1].strip():
                         page_to_chunk_ids.setdefault(new_page, set()).add(total_chunks + sub_chunk_id)
                         chunk_pages.add(new_page)
-                    
                     current_page = new_page
-
                 except (IndexError, ValueError):
                     continue
 
-            # Clean sub_chunk by removing page markers
             clean_chunk = re.sub(page_pattern, '', sub_chunk).strip()
-            
-            # Skip introduction chunks for embedding
+
             if c["heading"] == "Introduction":
                 continue
-            
-            # Prepare metadata
+
             meta = {
                 "filename": markdown_file,
                 "mode": chunk_config.to_string(),
@@ -146,59 +117,53 @@ def build_index(
                 "section_path": full_section_path,
                 "text_preview": clean_chunk[:100],
                 "page_numbers": sorted(list(chunk_pages)),
-                "chunk_id": total_chunks + sub_chunk_id
+                "chunk_id": total_chunks + sub_chunk_id,
             }
 
-            # Prepare chunk with prefix
-            if use_headings:
-                chunk_prefix = (
-                    f"Description: {full_section_path} "
-                    f"Content: "
-                )
-            else:
-                chunk_prefix = ""
+            chunk_prefix = (
+                f"Description: {full_section_path} Content: "
+                if use_headings else ""
+            )
 
-            all_chunks.append(chunk_prefix+clean_chunk)
+            all_chunks.append(chunk_prefix + clean_chunk)
             sources.append(markdown_file)
             metadata.append(meta)
 
         total_chunks += len(sub_chunks)
 
-    # Convert the sets to sorted lists for a clean, predictable output
-    final_map = {}
-    for page, id_set in page_to_chunk_ids.items():
-        final_map[page] = sorted(list(id_set))
-
+    # Save page-to-chunk map
+    final_map = {page: sorted(list(ids)) for page, ids in page_to_chunk_ids.items()}
     output_file = artifacts_dir / f"{index_prefix}_page_to_chunk_map.json"
     with open(output_file, "w") as f:
         json.dump(final_map, f, indent=2)
     print(f"Saved page to chunk ID map: {output_file}")
 
-    # Step 2: Create embeddings for FAISS index
-    print(f"Embedding {len(all_chunks):,} chunks with {pathlib.Path(embedding_model_path).stem} ...")
-    embedder = SentenceTransformer(embedding_model_path)
+    # Print chunk stats before embedding
+    print_chunk_stats(all_chunks, chunk_size_in_chars=chunk_config.recursive_chunk_size)
+
+    # Step 2: Load embedder
+    print(f"Loading embedding model (n_ctx={embedding_model_context_window})...")
+    embedder = SentenceTransformer(
+        embedding_model_path,
+        n_ctx=embedding_model_context_window,
+    )
+    print(f"Embedding {len(all_chunks):,} chunks sequentially...")
 
     if use_multiprocessing:
         print("Starting multi-process pool for embeddings...")
-        # Start the pool. Adjust number of workers as needed.
         pool = embedder.start_multi_process_pool(workers=4)
         try:
-            # Compute embeddings in parallel
             embeddings = embedder.encode_multi_process(
-                all_chunks, 
-                pool, 
-                batch_size=32
+                all_chunks,
+                pool,
+                batch_size=4,
             )
         finally:
-            # Stop the pool to prevent hanging processes
             embedder.stop_multi_process_pool(pool)
     else:
-        # Standard single-process embedding
         embeddings = embedder.encode(
-            all_chunks, 
-            batch_size=8, 
+            all_chunks,
             show_progress_bar=True,
-            convert_to_numpy=True 
         )
 
     # Step 3: Build FAISS index
@@ -207,7 +172,7 @@ def build_index(
     index = faiss.IndexFlatL2(dim)
     index.add(embeddings)
     faiss.write_index(index, str(artifacts_dir / f"{index_prefix}.faiss"))
-    print(f"FAISS Index built successfully: {index_prefix}.faiss")
+    print(f"FAISS index built: {index_prefix}.faiss")
 
     # Step 4: Build BM25 index
     print(f"Building BM25 index for {len(all_chunks):,} chunks...")
@@ -215,9 +180,9 @@ def build_index(
     bm25_index = BM25Okapi(tokenized_chunks)
     with open(artifacts_dir / f"{index_prefix}_bm25.pkl", "wb") as f:
         pickle.dump(bm25_index, f)
-    print(f"BM25 Index built successfully: {index_prefix}_bm25.pkl")
+    print(f"BM25 index built: {index_prefix}_bm25.pkl")
 
-    # Step 5: Dump index artifacts
+    # Step 5: Persist remaining artifacts
     with open(artifacts_dir / f"{index_prefix}_chunks.pkl", "wb") as f:
         pickle.dump(all_chunks, f)
     with open(artifacts_dir / f"{index_prefix}_sources.pkl", "wb") as f:
@@ -226,20 +191,9 @@ def build_index(
         pickle.dump(metadata, f)
     print(f"Saved all index artifacts with prefix: {index_prefix}")
 
-# ------------------------ Helper functions ------------------------------
 
 def preprocess_for_bm25(text: str) -> list[str]:
-    """
-    Simplifies text to keep only letters, numbers, underscores, hyphens,
-    apostrophes, plus, and hash — suitable for BM25 tokenization.
-    """
-    # Convert to lowercase
+    """Lowercase and tokenize text for BM25 indexing."""
     text = text.lower()
-
-    # Keep only allowed characters
     text = re.sub(r"[^a-z0-9_'#+-]", " ", text)
-
-    # Split by whitespace
-    tokens = text.split()
-
-    return tokens
+    return text.split()

--- a/src/index_builder.py
+++ b/src/index_builder.py
@@ -138,8 +138,8 @@ def build_index(
         json.dump(final_map, f, indent=2)
     print(f"Saved page to chunk ID map: {output_file}")
 
-    # Print chunk stats before embedding
-    print_chunk_stats(all_chunks, chunk_size_in_chars=chunk_config.recursive_chunk_size)
+    # Print chunk stats before embedding - TODO: wrap in some verbose cfg param
+    # print_chunk_stats(all_chunks, chunk_size_in_chars=chunk_config.recursive_chunk_size)
 
     # Step 2: Load embedder
     print(f"Loading embedding model (n_ctx={embedding_model_context_window})...")

--- a/src/main.py
+++ b/src/main.py
@@ -70,12 +70,12 @@ def run_index_mode(args: argparse.Namespace, cfg: RAGConfig):
         chunker=chunker,
         chunk_config=cfg.chunk_config,
         embedding_model_path=cfg.embed_model,
+        embedding_model_context_window=cfg.embedding_model_context_window,
         artifacts_dir=artifacts_dir,
         index_prefix=args.index_prefix,
         use_multiprocessing=args.multiproc_indexing,
         use_headings=args.embed_with_headings,
     )
-
 def use_indexed_chunks(question: str, chunks: list) -> list:
     # Logic for keyword matching from textbook index
     try:

--- a/src/preprocessing/chunking.py
+++ b/src/preprocessing/chunking.py
@@ -1,4 +1,5 @@
 import re
+import statistics
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Tuple, Optional
@@ -11,75 +12,175 @@ class ChunkConfig(ABC):
     @abstractmethod
     def validate(self):
         pass
-    
+
     @abstractmethod
     def to_string(self) -> str:
         pass
+
 
 @dataclass
 class SectionRecursiveConfig(ChunkConfig):
     """Configuration for section-based chunking with recursive splitting."""
     recursive_chunk_size: int
     recursive_overlap: int
-    
+
     def to_string(self) -> str:
-        return f"chunk_mode=sections+recursive, chunk_size={self.recursive_chunk_size}, overlap={self.recursive_overlap}"
+        return (
+            f"chunk_mode=sections+recursive, "
+            f"chunk_size={self.recursive_chunk_size}, "
+            f"overlap={self.recursive_overlap}"
+        )
 
     def validate(self):
         assert self.recursive_chunk_size > 0, "recursive_chunk_size must be > 0"
         assert self.recursive_overlap >= 0, "recursive_overlap must be >= 0"
+        assert self.recursive_overlap < self.recursive_chunk_size, \
+            "recursive_overlap must be less than recursive_chunk_size"
+
 
 # -------------------------- Chunking Strategies --------------------------
+
+# Separator hierarchy: tries the largest natural boundary first,
+# falling back to smaller ones only when a chunk still exceeds chunk_size.
+# The "" fallback guarantees a hard character-level split as a last resort.
+_RECURSIVE_SEPARATORS = [
+    "\n\n",   # paragraph break     — strongest preference
+    ". ",     # declarative sentence end
+    "? ",     # question end
+    "! ",     # exclamation end
+]
+
 
 class ChunkStrategy(ABC):
     """Abstract base for all chunking strategies."""
     @abstractmethod
     def name(self) -> str:
         pass
-    
+
     @abstractmethod
     def chunk(self, text: str) -> List[str]:
         pass
-    
+
     @abstractmethod
     def artifact_folder_name(self) -> str:
         pass
 
+
 class SectionRecursiveStrategy(ChunkStrategy):
     """
-    Applies recursive character-based splitting to text.
-    This is meant to be used on already-extracted sections.
+    Applies recursive character-based splitting to already-extracted sections.
+    Tries paragraph → line → sentence → word → character boundaries in order.
+    The "" fallback ensures no chunk can exceed chunk_size_in_chars.
     """
 
     def __init__(self, config: SectionRecursiveConfig):
         self.config = config
-        self.recursive_chunk_size = config.recursive_chunk_size
-        self.recursive_overlap = config.recursive_overlap
+        config.validate()
+        self._splitter = RecursiveCharacterTextSplitter(
+            chunk_size=config.recursive_chunk_size,
+            chunk_overlap=config.recursive_overlap,
+            separators=_RECURSIVE_SEPARATORS,
+            keep_separator=True,
+        )
 
     def name(self) -> str:
-        return f"sections+recursive({self.recursive_chunk_size},{self.recursive_overlap})"
+        return (
+            f"sections+recursive"
+            f"({self.config.recursive_chunk_size},{self.config.recursive_overlap})"
+        )
 
     def artifact_folder_name(self) -> str:
         return "sections"
 
     def chunk(self, text: str) -> List[str]:
-        """
-        Recursively splits text into smaller chunks based on sentence boundaries.
-        If a chunk exceeds recursive_chunk_size, it is further split.
-        """
-        splitter = RecursiveCharacterTextSplitter(
-            chunk_size=self.recursive_chunk_size,
-            chunk_overlap=self.recursive_overlap,
-            separators=[". "]
-        )
-        return splitter.split_text(text)
+        chunks = self._splitter.split_text(text)
+
+        # Post-split validation: the "" separator should prevent this,
+        # but log loudly if anything still slips through.
+        over_limit = [
+            (i, len(c)) for i, c in enumerate(chunks)
+            if len(c) > self.config.recursive_chunk_size
+        ]
+        if over_limit:
+            for idx, length in over_limit:
+                print(
+                    f"[WARNING] Chunk {idx} has {length} chars, "
+                    f"exceeding limit of {self.config.recursive_chunk_size}. "
+                    f"This should not happen with the '' fallback separator — "
+                    f"check for non-standard whitespace or very long tokens."
+                )
+
+        # Drop pure-whitespace chunks
+        return [c for c in chunks if c.strip()]
+
+
+# -------------------------- Chunk Stats --------------------------
+
+def print_chunk_stats(chunks: List[str], chunk_size_in_chars: int) -> None:
+    """
+    Prints a statistical summary of chunk character lengths.
+    Useful for diagnosing chunking quality and context window overflow risk.
+
+    Args:
+        chunks:             List of chunk strings to analyse.
+        chunk_size_in_chars: The configured hard limit, used to flag overflows.
+    """
+    if not chunks:
+        print("[Chunk Stats] No chunks to analyse.")
+        return
+
+    lengths = [len(c) for c in chunks]
+    total = len(lengths)
+    over = [l for l in lengths if l > chunk_size_in_chars]
+    pct_over = (len(over) / total) * 100
+
+    # Rough token estimate at 4 chars/token
+    est_tokens = [l / 4.0 for l in lengths]
+
+    print("\n" + "="*55)
+    print("  CHUNK STATS")
+    print("="*55)
+    print(f"  Total chunks          : {total:,}")
+    print(f"  Char limit            : {chunk_size_in_chars:,}")
+    print(f"  --- Character lengths ---")
+    print(f"  Min                   : {min(lengths):,}")
+    print(f"  Max                   : {max(lengths):,}")
+    print(f"  Mean                  : {statistics.mean(lengths):,.1f}")
+    print(f"  Median                : {statistics.median(lengths):,.1f}")
+    print(f"  Stdev                 : {statistics.stdev(lengths):,.1f}" if total > 1 else "  Stdev                 : N/A")
+    print(f"  --- Token estimates (chars ÷ 4) ---")
+    print(f"  Min                   : {min(est_tokens):.0f}")
+    print(f"  Max                   : {max(est_tokens):.0f}")
+    print(f"  Mean                  : {statistics.mean(est_tokens):.1f}")
+    print(f"  --- Overflow ---")
+    print(f"  Chunks over limit     : {len(over):,} / {total:,}  ({pct_over:.1f}%)")
+    if over:
+        print(f"  Largest offender      : {max(over):,} chars (~{max(over)/4:.0f} tokens)")
+
+    print(f"  --- Distribution ---")
+    buckets = [
+        ("  0 – 500  chars", 0, 500),
+        ("501 – 1000 chars", 501, 1000),
+        ("1001 – 1500 chars", 1001, 1500),
+        ("1501 – 2000 chars", 1501, 2000),
+        ("2001 – 2500 chars", 2001, 2500),
+        ("2500+      chars", 2501, float("inf")),
+    ]
+    for label, lo, hi in buckets:
+        count = sum(1 for l in lengths if lo <= l <= hi)
+        bar = "█" * (count * 30 // total) if total else ""
+        print(f"  {label}: {count:>5,}  {bar}")
+    print("="*55 + "\n")
+
 
 # ----------------------------- Document Chunker ---------------------------------
 
 class DocumentChunker:
     """
-    Chunk text via a provided strategy.
-    Table blocks (<table>...</table>) are preserved within chunks.
+    Chunks text via a provided strategy.
+    Table blocks (<table>...</table>) are preserved as atomic units —
+    extracted before splitting and restored into whichever chunk holds
+    their placeholder.
     """
 
     TABLE_RE = re.compile(r"<table>.*?</table>", re.DOTALL | re.IGNORECASE)
@@ -87,7 +188,7 @@ class DocumentChunker:
     def __init__(
         self,
         strategy: Optional[ChunkStrategy],
-        keep_tables: bool = True
+        keep_tables: bool = True,
     ):
         self.strategy = strategy
         self.keep_tables = keep_tables
@@ -101,24 +202,41 @@ class DocumentChunker:
     @staticmethod
     def _restore_tables(chunk: str, tables: List[str]) -> str:
         for i, t in enumerate(tables):
-            ph = f"[TABLE_PLACEHOLDER_{i}]"
-            if ph in chunk:
-                chunk = chunk.replace(ph, t)
+            chunk = chunk.replace(f"[TABLE_PLACEHOLDER_{i}]", t)
         return chunk
+
+    def _check_split_placeholders(self, chunks: List[str], num_tables: int) -> None:
+        """Warn if a table placeholder ended up in more than one chunk."""
+        ph_pattern = re.compile(r"\[TABLE_PLACEHOLDER_(\d+)\]")
+        seen = {}
+        for chunk_idx, chunk in enumerate(chunks):
+            for match in ph_pattern.finditer(chunk):
+                table_idx = int(match.group(1))
+                if table_idx in seen:
+                    print(
+                        f"[WARNING] TABLE_PLACEHOLDER_{table_idx} appears in "
+                        f"both chunk {seen[table_idx]} and chunk {chunk_idx}. "
+                        f"Table may be duplicated or lost."
+                    )
+                seen[table_idx] = chunk_idx
 
     def chunk(self, text: str) -> List[str]:
         if not text:
             return []
-        work = text
+
         tables: List[str] = []
+        work = text
+
         if self.keep_tables:
             work, tables = self._extract_tables(work)
 
         if self.strategy is None:
             raise ValueError("No chunk strategy provided")
-        else:
-            chunks = self.strategy.chunk(work)
+
+        chunks = self.strategy.chunk(work)
 
         if self.keep_tables and tables:
+            self._check_split_placeholders(chunks, len(tables))
             chunks = [self._restore_tables(c, tables) for c in chunks]
+
         return chunks

--- a/src/preprocessing/chunking.py
+++ b/src/preprocessing/chunking.py
@@ -40,14 +40,12 @@ class SectionRecursiveConfig(ChunkConfig):
 
 # -------------------------- Chunking Strategies --------------------------
 
-# Separator hierarchy: tries the largest natural boundary first,
-# falling back to smaller ones only when a chunk still exceeds chunk_size.
 # The "" fallback guarantees a hard character-level split as a last resort.
 _RECURSIVE_SEPARATORS = [
-    "\n\n",   # paragraph break     — strongest preference
     ". ",     # declarative sentence end
     "? ",     # question end
     "! ",     # exclamation end
+    "",
 ]
 
 
@@ -94,22 +92,7 @@ class SectionRecursiveStrategy(ChunkStrategy):
 
     def chunk(self, text: str) -> List[str]:
         chunks = self._splitter.split_text(text)
-
-        # Post-split validation: the "" separator should prevent this,
-        # but log loudly if anything still slips through.
-        over_limit = [
-            (i, len(c)) for i, c in enumerate(chunks)
-            if len(c) > self.config.recursive_chunk_size
-        ]
-        if over_limit:
-            for idx, length in over_limit:
-                print(
-                    f"[WARNING] Chunk {idx} has {length} chars, "
-                    f"exceeding limit of {self.config.recursive_chunk_size}. "
-                    f"This should not happen with the '' fallback separator — "
-                    f"check for non-standard whitespace or very long tokens."
-                )
-
+        
         # Drop pure-whitespace chunks
         return [c for c in chunks if c.strip()]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,7 +93,7 @@ rrf_k: 50
         from src.config import RAGConfig
         from src.preprocessing.chunking import SectionRecursiveConfig
         
-        cfg = RAGConfig(chunk_mode="recursive_sections", chunk_size=1000, chunk_overlap=100)
+        cfg = RAGConfig(chunk_mode="recursive_sections", chunk_size_in_chars=1000, chunk_overlap=100)
         
         assert isinstance(cfg.chunk_config, SectionRecursiveConfig)
         assert cfg.chunk_config.recursive_chunk_size == 1000
@@ -737,7 +737,7 @@ class TestEndToEndAPIContracts:
         from src.config import RAGConfig
         from src.preprocessing.chunking import SectionRecursiveStrategy
         
-        cfg = RAGConfig(chunk_mode="recursive_sections", chunk_size=500, chunk_overlap=50)
+        cfg = RAGConfig(chunk_mode="recursive_sections", chunk_size_in_chars=500, chunk_overlap=50)
         strategy = cfg.get_chunk_strategy()
         
         assert isinstance(strategy, SectionRecursiveStrategy)


### PR DESCRIPTION
Reverts to sequential single model call per chunk when creating embeddings during index creation. Current llama.cpp version does not support n_seq_max param and thus native batching results in errors. Alternative batching would entail loading batch_size copies of the model into memory which would flood the memory. Also fixes chunking to ensure we have appropriate sized chunks.

Same as PR 102 (but isolated)