### PR TITLE
Fix quiz feedback: re-retrieve sources for grading and validate feedback structure

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -61,10 +61,12 @@ import {
 import { buildRetrievalContext, mergeChatSources } from '@shared/chat-context'
 import {
   quizFeedbackPrompt,
+  quizFeedbackRetryPrompt,
   quizQuestionPrompt,
   quizSourcePoolSize,
   quizSourceLimit,
-  quizTotalQuestions
+  quizTotalQuestions,
+  validateQuizFeedback
 } from '@shared/quiz'
 import tokensmithAssistantMark from './assets/tokensmith-assistant-mark.png'
 import tokensmithRailWordmark from './assets/tokensmith-rail-wordmark.png'
@@ -3682,7 +3684,23 @@ function ChatScreen({
     const activeModelSettings = modelSettingsFor(settings, selectedModel.id)
 
     try {
-      const retrievedSources = quizState.currentSources
+      const feedbackQuery = `${quizState.currentQuestion}\n${answer}`
+      let retrievedSources = quizState.currentSources
+      if (window.tokensmith && activeMaterials.length > 0) {
+        try {
+          const searchEmbeddingModels = embeddingModelsForMaterials(activeMaterials, embeddingModels)
+          const searchResults = await window.tokensmith.searchLibrary(
+            feedbackQuery,
+            activeMaterials,
+            quizSourceLimit,
+            searchEmbeddingModels
+          )
+          if (searchResults.length > 0) {
+            retrievedSources = searchResults
+          }
+        } catch (searchError) {
+        }
+      }
 
       if (requestSequenceRef.current !== requestSequence) {
         return
@@ -3693,13 +3711,15 @@ function ChatScreen({
       }
 
       setPendingSources(settings.application.showSources ? retrievedSources : [])
+      const feedbackPrompt = quizFeedbackPrompt({
+        answer,
+        question: quizState.currentQuestion,
+        questionNumber: quizState.questionNumber,
+        totalQuestions: quizState.totalQuestions
+      })
+
       const reply = await window.tokensmith?.sendChatMessage({
-        prompt: quizFeedbackPrompt({
-          answer,
-          question: quizState.currentQuestion,
-          questionNumber: quizState.questionNumber,
-          totalQuestions: quizState.totalQuestions
-        }),
+        prompt: feedbackPrompt,
         messages: activeConversation.messages,
         materials: activeMaterials,
         model: selectedModel,
@@ -3717,17 +3737,38 @@ function ChatScreen({
         return
       }
 
+      const feedbackCheck = validateQuizFeedback(reply.text)
+      let feedbackText = reply.text
+      let feedbackSources = reply.sources
+      if (!feedbackCheck.valid) {
+        const retryReply = await window.tokensmith?.sendChatMessage({
+          prompt: quizFeedbackRetryPrompt(feedbackPrompt, feedbackCheck.issues),
+          messages: activeConversation.messages,
+          materials: activeMaterials,
+          model: selectedModel,
+          settings,
+          applicationSettings: quizApplicationSettings(settings.application),
+          modelSettings: activeModelSettings,
+          retrievedSources
+        })
+
+        if (retryReply && validateQuizFeedback(retryReply.text).valid) {
+          feedbackText = retryReply.text
+          feedbackSources = retryReply.sources
+        }
+      }
+
       const feedbackMessage: ChatMessage = {
         id: createId('assistant'),
         role: 'assistant',
-        text: reply.text,
+        text: feedbackText,
         kind: 'quizFeedback',
         quiz: {
           questionNumber: quizState.questionNumber,
           totalQuestions: quizState.totalQuestions,
           complete: quizState.questionNumber >= quizState.totalQuestions
         },
-        sources: settings.application.showSources ? reply.sources : []
+        sources: settings.application.showSources ? feedbackSources : []
       }
       const nextQuestionNumber = quizState.questionNumber + 1
       let nextQuestionMessage: ChatMessage | undefined

--- a/src/shared/quiz.ts
+++ b/src/shared/quiz.ts
@@ -10,6 +10,10 @@ const quizFocusAreas = [
   'edge cases, limitations, common mistakes, or consequences'
 ]
 
+const quizFeedbackGradePattern = /^(Good|Partial|Needs work)\b/i
+const quizFeedbackExpectedAnswerPattern = /Expected answer:/i
+const quizFeedbackLocatorPattern = /\b(page|section|chapter|excerpt|source|passage)\s+[\dIVXLC]/i
+
 function quizFocusArea(questionNumber: number): string {
   return quizFocusAreas[Math.max(0, questionNumber - 1) % quizFocusAreas.length]
 }
@@ -78,5 +82,26 @@ export function quizFeedbackPrompt({
     '',
     `Quiz question ${questionNumber} of ${totalQuestions}: ${question}`,
     `Student answer: ${answer}`
+  ].join('\n')
+}
+
+export function validateQuizFeedback(text: string) {
+  const trimmed = text.trim()
+  const issues: string[] = []
+
+  if (!quizFeedbackGradePattern.test(trimmed)) issues.push('missing_grade_prefix')
+  if (!quizFeedbackExpectedAnswerPattern.test(trimmed)) issues.push('missing_expected_answer')
+  if (quizFeedbackLocatorPattern.test(trimmed)) issues.push('locator_reference')
+
+  return { valid: issues.length === 0, issues }
+}
+
+export function quizFeedbackRetryPrompt(basePrompt: string, issues: string[]): string {
+  return [
+    basePrompt,
+    '',
+    'Your previous response did not follow the required format. Specifically:',
+    ...issues.map((issue) => `- ${issue}`),
+    'Respond again, following the required format exactly. Do not change the question or answer.'
   ].join('\n')
 }


### PR DESCRIPTION
Quiz feedback was often vague or incomplete because the source chunks were selected randomly for each question and then reused unchanged all the way through grading, with no re-retrieval based on the actual question or the student's answer. 

Fixes this issue by implementing the FAISS similarity index that is used for regular chat, re-retrieving sources using the question and the answer. If this fails then it falls back to the original sources. validateQuizFeedback() also added to check that the feedback follows the correct format, and gets corrected before reaching the user if it is in the incorrect format.