### PR TITLE
Add keyword (BM25) and hybrid search modes

### DIFF
--- a/python_engine/tokensmith_engine.py
+++ b/python_engine/tokensmith_engine.py
@@ -20,7 +20,7 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 from datetime import datetime
 
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
@@ -46,6 +46,8 @@ if _NEEDS_STORE:
             find_material_id_by_import_path,
             has_chunks,
             init_db,
+            keyword_search,
+            keyword_terms_for_query,
             list_materials,
             set_material_active,
             source_document_for_source,
@@ -66,6 +68,8 @@ if _NEEDS_STORE:
             find_material_id_by_import_path,
             has_chunks,
             init_db,
+            keyword_search,
+            keyword_terms_for_query,
             list_materials,
             set_material_active,
             source_document_for_source,
@@ -1800,12 +1804,71 @@ def no_enabled_materials_reason(user_data_path: str) -> str:
     return "no_materials"
 
 
+SEARCH_MODES = ("vector", "keyword", "hybrid")
+DEFAULT_SEARCH_MODE = "hybrid"
+RRF_RANK_CONSTANT = 60.0
+HYBRID_KEYWORD_WEIGHT = 1.5
+HYBRID_VECTOR_WEIGHT = 1.0
+
+
+def normalize_search_mode(value: Any) -> str:
+    mode = str(value or "").strip().lower()
+    return mode if mode in SEARCH_MODES else DEFAULT_SEARCH_MODE
+
+
+def reciprocal_rank_fusion(
+    rankings: Sequence[Tuple[float, Sequence[int]]],
+    limit: int,
+    rank_constant: float = RRF_RANK_CONSTANT,
+) -> List[Tuple[int, float]]:
+    scores: Dict[int, float] = {}
+    first_seen: Dict[int, int] = {}
+    order = 0
+
+    for weight, rowids in rankings:
+        if weight <= 0:
+            continue
+        for index, rowid in enumerate(rowids):
+            if rowid not in first_seen:
+                first_seen[rowid] = order
+                order += 1
+            scores[rowid] = scores.get(rowid, 0.0) + (weight / (rank_constant + index + 1))
+
+    ranked = sorted(scores.items(), key=lambda item: (-item[1], first_seen[item[0]]))
+    return ranked[:limit]
+
+
+def combine_search_hits(
+    mode: str,
+    vector_hits: Sequence[Tuple[int, float]],
+    keyword_hits: Sequence[Tuple[int, float]],
+    limit: int,
+) -> List[Tuple[int, float]]:
+    vector_ranked = sorted(vector_hits, key=lambda item: item[1], reverse=True)
+    keyword_ranked = list(keyword_hits)
+
+    if mode == "vector":
+        return vector_ranked[:limit]
+    if mode == "keyword":
+        return keyword_ranked[:limit]
+
+    return reciprocal_rank_fusion(
+        [
+            (HYBRID_KEYWORD_WEIGHT, [rowid for rowid, _score in keyword_ranked]),
+            (HYBRID_VECTOR_WEIGHT, [rowid for rowid, _score in vector_ranked]),
+        ],
+        limit,
+    )
+
+
 def search_library(payload: Dict[str, Any]) -> Dict[str, Any]:
     user_data_path = payload["userDataPath"]
     init_db(user_data_path)
 
     query = payload.get("query", "")
     limit = int(payload.get("limit") or 4)
+    search_mode = normalize_search_mode(payload.get("searchMode"))
+    candidate_limit = max(limit * 8, limit) if search_mode == "hybrid" else limit
     materials = payload.get("materials") or []
     embedding_specs = embedding_model_specs(payload)
     requested_active_materials = [
@@ -1840,7 +1903,9 @@ def search_library(payload: Dict[str, Any]) -> Dict[str, Any]:
     vector_hits_by_rowid: Dict[int, Tuple[float, str]] = {}
     skipped_embedding_models: List[str] = []
 
-    for embedding_key, grouped_active_ids in active_ids_by_embedding_model.items():
+    for embedding_key, grouped_active_ids in (
+        active_ids_by_embedding_model.items() if search_mode in ("vector", "hybrid") else []
+    ):
         log_event("search_embedding_provider_resolve_start", embeddingKey=embedding_key)
         embed_text, embedding_reason = resolve_embedding_provider_for_key(embedding_key, embedding_specs)
         log_event(
@@ -1861,33 +1926,40 @@ def search_library(payload: Dict[str, Any]) -> Dict[str, Any]:
             skipped_embedding_models.append(embedding_key)
             continue
 
-        for rowid, score in vector_search(user_data_path, query_embedding, grouped_active_ids, limit, embedding_key):
+        for rowid, score in vector_search(
+            user_data_path, query_embedding, grouped_active_ids, candidate_limit, embedding_key
+        ):
             current = vector_hits_by_rowid.get(rowid)
             if current is None or score > current[0]:
                 vector_hits_by_rowid[rowid] = (score, embedding_key)
 
-    vector_hits_with_models = sorted(
-        ((rowid, score, embedding_key) for rowid, (score, embedding_key) in vector_hits_by_rowid.items()),
-        key=lambda item: item[1],
-        reverse=True,
-    )
+    keyword_terms: List[str] = []
+    keyword_hits: List[Tuple[int, float]] = []
+    if search_mode in ("keyword", "hybrid"):
+        keyword_terms = keyword_terms_for_query(user_data_path, query, active_ids)
+        keyword_hits = keyword_search(user_data_path, query, active_ids, candidate_limit, keyword_terms)
+
+    vector_hits = [(rowid, score) for rowid, (score, _key) in vector_hits_by_rowid.items()]
+    ranked = combine_search_hits(search_mode, vector_hits, keyword_hits, limit)
+
     log_event(
         "search_results_ranked",
         queryChars=len(query),
+        searchMode=search_mode,
         embeddingModels=list(active_ids_by_embedding_model),
         skippedEmbeddingModels=skipped_embedding_models,
-        vectorHits=len(vector_hits_with_models),
-        topMode="vector" if vector_hits_with_models else None,
+        vectorHits=len(vector_hits),
+        keywordHits=len(keyword_hits),
+        keywordTerms=keyword_terms,
+        rankedHits=len(ranked),
     )
 
-    row_embedding_models = {rowid: embedding_key for rowid, _score, embedding_key in vector_hits_with_models}
-    rows = fetch_sources(
-        user_data_path,
-        [(rowid, score) for rowid, score, _embedding_key in vector_hits_with_models[:limit]],
-        active_ids,
-    )
+    row_embedding_models = {
+        rowid: embedding_key for rowid, (_score, embedding_key) in vector_hits_by_rowid.items()
+    }
+    rows = fetch_sources(user_data_path, ranked, active_ids)
     for row in rows:
-        row["retrieval_mode"] = "vector"
+        row["retrieval_mode"] = search_mode
         row["query_embedding_model"] = row_embedding_models.get(int(row["rowid"]))
     sources = [source_from_sqlite_chunk(row, query_tokens) for row in rows]
     return {"sources": sources, "reason": None if sources else "no_matching_sources"}
@@ -1957,6 +2029,7 @@ DEFAULT_APPLICATION_SETTINGS: Dict[str, Any] = {
     "cpuThreads": 4,
     "suggestionMode": "on",
     "followUpSuggestionCount": DEFAULT_FOLLOW_UP_SUGGESTION_COUNT,
+    "searchMode": DEFAULT_SEARCH_MODE,
 }
 
 def clamp_number(value: Any, default_value: float, minimum: float, maximum: float) -> float:
@@ -1995,6 +2068,7 @@ def normalize_application_settings(settings: Optional[Dict[str, Any]]) -> Dict[s
         "cpuThreads": int(round(clamp_number(settings.get("cpuThreads"), DEFAULT_APPLICATION_SETTINGS["cpuThreads"], 1, 64))),
         "suggestionMode": suggestion_mode,
         "followUpSuggestionCount": follow_up_count,
+        "searchMode": normalize_search_mode(settings.get("searchMode")),
     }
 
 
@@ -2364,6 +2438,7 @@ def chat(payload: Dict[str, Any]) -> Dict[str, Any]:
                     "limit": limit,
                     "model": model,
                     "embeddingModels": payload.get("embeddingModels") or [],
+                    "searchMode": application_settings.get("searchMode"),
                 }
             )
             sources = search_result["sources"]

--- a/python_engine/tokensmith_store.py
+++ b/python_engine/tokensmith_store.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import math
 import random
+import re
 import sqlite3
 import time
 from datetime import datetime
@@ -19,6 +21,110 @@ except Exception:  # pragma: no cover - optional until app runtime is installed
 DB_NAME = "tokensmith.sqlite"
 FAISS_NAME = "tokensmith.faiss"
 SCHEMA_VERSION = 9
+KEYWORD_STOPWORDS: Set[str] = {
+    "a",
+    "about",
+    "above",
+    "after",
+    "again",
+    "all",
+    "also",
+    "am",
+    "an",
+    "and",
+    "any",
+    "are",
+    "as",
+    "at",
+    "be",
+    "because",
+    "been",
+    "before",
+    "being",
+    "between",
+    "but",
+    "by",
+    "can",
+    "cant",
+    "cannot",
+    "could",
+    "did",
+    "do",
+    "does",
+    "doing",
+    "dont",
+    "down",
+    "during",
+    "each",
+    "few",
+    "for",
+    "from",
+    "had",
+    "has",
+    "have",
+    "having",
+    "how",
+    "i",
+    "if",
+    "in",
+    "into",
+    "is",
+    "it",
+    "its",
+    "just",
+    "may",
+    "me",
+    "more",
+    "most",
+    "need",
+    "no",
+    "not",
+    "of",
+    "on",
+    "only",
+    "or",
+    "our",
+    "over",
+    "same",
+    "should",
+    "so",
+    "some",
+    "such",
+    "than",
+    "that",
+    "the",
+    "their",
+    "then",
+    "there",
+    "these",
+    "they",
+    "this",
+    "those",
+    "through",
+    "to",
+    "too",
+    "under",
+    "up",
+    "use",
+    "used",
+    "using",
+    "was",
+    "we",
+    "were",
+    "what",
+    "when",
+    "where",
+    "whether",
+    "which",
+    "while",
+    "who",
+    "why",
+    "will",
+    "with",
+    "would",
+}
+MAX_KEYWORD_QUERY_TERMS = 8
+MAX_ANCHOR_DF_RATIO = 0.20
 
 
 def db_path(user_data_path: str) -> Path:
@@ -1018,6 +1124,171 @@ def vector_search(
     allowed = {int(chunk["rowid"]) for chunk in allowed_chunks}
 
     return [(rowid, score) for rowid, score in raw if rowid in allowed][:limit]
+
+
+def _active_chunks_filter(active_material_ids: Sequence[str]) -> Tuple[str, List[str]]:
+    active_placeholders = ",".join("?" for _ in active_material_ids)
+    return (
+        f"""
+        EXISTS (
+            SELECT 1
+            FROM chunks ch
+            JOIN documents d ON d.id = ch.document_id
+            JOIN collection_items ci ON ci.folder_id = d.folder_id
+            JOIN tokensmith_collection_state s ON s.collection_id = ci.collection_id
+            WHERE ch.id = chunks_fts.rowid
+              AND CAST(ci.collection_id AS TEXT) IN ({active_placeholders})
+              AND s.status = 'ready'
+              AND s.is_active = 1
+        )
+        """,
+        [str(material_id) for material_id in active_material_ids],
+    )
+
+
+def keyword_query_terms(query: str) -> List[str]:
+    terms: List[str] = []
+    seen: Set[str] = set()
+    for raw_term in re.findall(r"[0-9A-Za-z]+", query or ""):
+        term = raw_term.casefold()
+        if len(term) < 2 or term in KEYWORD_STOPWORDS or term in seen:
+            continue
+        terms.append(term)
+        seen.add(term)
+    return terms
+
+
+def build_fts_match_query(terms: Sequence[str], operator: str = "OR") -> str:
+    safe_terms = []
+    for term in terms:
+        normalized = str(term).casefold()
+        if re.fullmatch(r"[0-9a-z]+", normalized):
+            safe_terms.append(normalized)
+    if not safe_terms:
+        return ""
+    joiner = " " if operator == "AND" else " OR "
+    return joiner.join(f'"{term}"' for term in safe_terms)
+
+
+def keyword_terms_for_query(
+    user_data_path: str,
+    query: str,
+    active_material_ids: Sequence[str],
+    max_terms: int = MAX_KEYWORD_QUERY_TERMS,
+) -> List[str]:
+    terms = keyword_query_terms(query)
+    if not terms or not active_material_ids or max_terms <= 0:
+        return []
+
+    active_filter, active_params = _active_chunks_filter(active_material_ids)
+    with connect(user_data_path) as conn:
+        total_chunks = conn.execute(
+            f"""
+            SELECT COUNT(DISTINCT chunks_fts.rowid)
+            FROM chunks_fts
+            WHERE {active_filter}
+            """,
+            active_params,
+        ).fetchone()[0]
+
+        if not total_chunks:
+            return []
+
+        ranked_terms: List[Tuple[str, float, int, int]] = []
+        fallback_terms: List[Tuple[str, float, int, int]] = []
+        for index, term in enumerate(terms):
+            try:
+                df = int(
+                    conn.execute(
+                        f"""
+                        SELECT COUNT(DISTINCT chunks_fts.rowid)
+                        FROM chunks_fts
+                        WHERE chunks_fts MATCH ?
+                          AND {active_filter}
+                        """,
+                        [build_fts_match_query([term]), *active_params],
+                    ).fetchone()[0]
+                )
+            except sqlite3.OperationalError:
+                continue
+
+            if df <= 0:
+                continue
+
+            idf = math.log((float(total_chunks) + 1.0) / (float(df) + 1.0)) + 1.0
+            term_rank = (term, idf, df, index)
+            fallback_terms.append(term_rank)
+            if df / float(total_chunks) <= MAX_ANCHOR_DF_RATIO or len(term) >= 4:
+                ranked_terms.append(term_rank)
+
+    chosen_terms = ranked_terms or fallback_terms
+    chosen_terms.sort(key=lambda item: (-item[1], item[2], item[3]))
+    return [term for term, _idf, _df, _index in chosen_terms[:max_terms]]
+
+
+def keyword_search_with_match_query(
+    user_data_path: str,
+    match_query: str,
+    active_material_ids: Sequence[str],
+    limit: int,
+) -> List[Tuple[int, float]]:
+    if not active_material_ids or not match_query:
+        return []
+
+    active_filter, active_params = _active_chunks_filter(active_material_ids)
+
+    with connect(user_data_path) as conn:
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT rowid AS rowid, bm25(chunks_fts) AS score
+                FROM chunks_fts
+                WHERE chunks_fts MATCH ?
+                  AND {active_filter}
+                ORDER BY score
+                LIMIT ?
+                """,
+                [match_query, *active_params, limit],
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+
+    # bm25() is lower-is-better; flip the sign so higher means more relevant, like the vector scores.
+    return [(int(row["rowid"]), -float(row["score"])) for row in rows]
+
+
+def keyword_search(
+    user_data_path: str,
+    query: str,
+    active_material_ids: Sequence[str],
+    limit: int,
+    terms: Optional[Sequence[str]] = None,
+) -> List[Tuple[int, float]]:
+    """Rank chunks by BM25 relevance over the chunks_fts index."""
+    if not active_material_ids:
+        return []
+
+    match_terms = list(terms) if terms is not None else keyword_terms_for_query(user_data_path, query, active_material_ids)
+    if not match_terms:
+        return []
+
+    match_queries = []
+    if len(match_terms) > 1:
+        match_queries.append(build_fts_match_query(match_terms, "AND"))
+    match_queries.append(build_fts_match_query(match_terms, "OR"))
+
+    seen: Set[int] = set()
+    hits: List[Tuple[int, float]] = []
+    for match_query in match_queries:
+        for rowid, score in keyword_search_with_match_query(user_data_path, match_query, active_material_ids, limit):
+            if rowid in seen:
+                continue
+            hits.append((rowid, score))
+            seen.add(rowid)
+            if len(hits) >= limit:
+                return hits
+
+    return hits
 
 
 def fetch_sources(

--- a/src/main/engine/study-chat-format.ts
+++ b/src/main/engine/study-chat-format.ts
@@ -8,6 +8,16 @@ import {
 
 export type StudyChatMessage = { role: 'system' | 'user' | 'assistant'; content: string }
 
+const maxSourceContextChars = 2400
+
+function sourceText(source: ChatSource): string {
+  const text = (source.context || source.excerpt).trim()
+  if (text.length <= maxSourceContextChars) {
+    return text
+  }
+  return `${text.slice(0, maxSourceContextChars - 3).trim()}...`
+}
+
 export function sourceContext(sources: ChatSource[]): string {
   if (sources.length === 0) {
     return ''
@@ -23,7 +33,7 @@ export function sourceContext(sources: ChatSource[]): string {
       const collection = source.collectionName || source.documentTitle || source.title || 'Library'
       const path = source.path || source.title || ''
       const section = source.sectionHeader ? `Section: ${source.sectionHeader}\n` : ''
-      return `Collection: ${collection}\nPath: ${path}\n${section}Text: ${source.excerpt}`
+      return `Collection: ${collection}\nPath: ${path}\n${section}Text: ${sourceText(source)}`
     })
   ].join('\n')
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,7 +34,7 @@ import {
   rememberRemoteModelApiKeys,
   sanitizeAppStateSecrets
 } from './engine/remote-model-secrets'
-import type { AppStateSnapshot, ChatSource, CourseMaterial, LocalModel, LocalModelRole } from '../shared/app-state'
+import type { AppStateSnapshot, ChatSource, CourseMaterial, LocalModel, LocalModelRole, SearchMode } from '../shared/app-state'
 import type { CleaningProfileId, CleaningRuleId } from '../shared/cleaning'
 import type {
   EngineChatRequest,
@@ -446,8 +446,8 @@ app.whenReady().then(() => {
   ipcMain.handle('library:starter-sources', (_event, materials: CourseMaterial[], limit?: number) =>
     starterSourcesWithPython(materials, limit)
   )
-  ipcMain.handle('library:search', (_event, query: string, materials: CourseMaterial[], limit: number, embeddingModels?: LocalModel[]) =>
-    searchLibraryWithPython(query, materials, limit, embeddingModels)
+  ipcMain.handle('library:search', (_event, query: string, materials: CourseMaterial[], limit: number, embeddingModels?: LocalModel[], searchMode?: SearchMode) =>
+    searchLibraryWithPython(query, materials, limit, embeddingModels, searchMode)
   )
   ipcMain.handle('library:get-pdf-for-source', (_event, source: ChatSource) => getPdfForSource(source))
   ipcMain.handle('library:get-pdf-thumbnail-for-source', (_event, source: ChatSource) =>

--- a/src/main/python/python-engine-service.ts
+++ b/src/main/python/python-engine-service.ts
@@ -3,7 +3,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { delimiter, dirname, join } from 'node:path'
 import { createInterface } from 'node:readline'
-import type { ChatSource, CourseMaterial, LocalModel, MaterialIndexProgress } from '../../shared/app-state'
+import type { ChatSource, CourseMaterial, LocalModel, MaterialIndexProgress, SearchMode } from '../../shared/app-state'
 import type { CleaningPreviewResult, TokenSmithLogFile } from '../../shared/engine'
 import type { CleaningProfileId, CleaningRuleId } from '../../shared/cleaning'
 
@@ -592,12 +592,14 @@ export async function searchLibraryWithPython(
   query: string,
   materials: CourseMaterial[],
   limit: number,
-  embeddingModels?: LocalModel[]
+  embeddingModels?: LocalModel[],
+  searchMode?: SearchMode
 ): Promise<ChatSource[]> {
   const resolvedEmbeddingModels = resolveEmbeddingModels(embeddingModels)
   writeLog('library_search_request', {
     query,
     limit,
+    searchMode,
     materials: materials.map((material) => ({
       id: material.id,
       title: material.title,
@@ -621,6 +623,7 @@ export async function searchLibraryWithPython(
       materials,
       limit,
       embeddingModels: resolvedEmbeddingModels,
+      searchMode,
       userDataPath: app.getPath('userData')
     },
     30_000

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,8 +21,8 @@ const tokenSmithBridge: TokenSmithBridge = {
     ipcRenderer.invoke('library:starter-sources', materials, limit) as Promise<
       Awaited<ReturnType<TokenSmithBridge['starterSources']>>
     >,
-  searchLibrary: (query, materials, limit, embeddingModels) =>
-    ipcRenderer.invoke('library:search', query, materials, limit, embeddingModels) as Promise<
+  searchLibrary: (query, materials, limit, embeddingModels, searchMode) =>
+    ipcRenderer.invoke('library:search', query, materials, limit, embeddingModels, searchMode) as Promise<
       Awaited<ReturnType<TokenSmithBridge['searchLibrary']>>
     >,
   getPdfForSource: (source) =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -181,6 +181,7 @@ const defaultApplicationSettings: ApplicationSettings = {
   fontSize: 'small',
   defaultModelId: '',
   suggestionMode: 'on',
+  searchMode: 'hybrid',
   followUpSuggestionCount: defaultFollowUpSuggestionCount,
   showSources: true,
   cpuThreads: 4
@@ -836,6 +837,7 @@ function normalizeApplicationSettings(settings?: Partial<ApplicationSettings>, m
     fontSize: normalizeChoice(settings?.fontSize, ['small', 'medium', 'large'] as const, defaultApplicationSettings.fontSize),
     defaultModelId,
     suggestionMode,
+    searchMode: normalizeChoice(settings?.searchMode, ['vector', 'keyword', 'hybrid'] as const, defaultApplicationSettings.searchMode),
     followUpSuggestionCount: normalizeFollowUpSuggestionCount(settings?.followUpSuggestionCount, suggestionMode),
     showSources: settings?.showSources ?? defaultApplicationSettings.showSources,
     cpuThreads: Math.round(clampNumber(settings?.cpuThreads, defaultApplicationSettings.cpuThreads, 1, 64))
@@ -3930,7 +3932,8 @@ function ChatScreen({
           retrievalContext.query,
           activeMaterials,
           settings.maxSources,
-          searchEmbeddingModels
+          searchEmbeddingModels,
+          settings.application.searchMode
         )
         retrievedSources = mergeChatSources(retrievalContext.carriedSources, searchResults, settings.maxSources)
 
@@ -7203,6 +7206,23 @@ function SettingsScreen({
             </SettingsGroup>
 
             <SettingsGroup title="Advanced">
+              <SettingsRow
+                label="Search Mode"
+                description="How library sources are retrieved: meaning (vector) matches on topic, keyword (BM25) matches on exact words, and hybrid blends both."
+              >
+                <SelectField
+                  ariaLabel="Search mode"
+                  value={settings.application.searchMode}
+                  onChange={(searchMode) =>
+                    updateApplicationSettings({ searchMode: searchMode as ApplicationSettings['searchMode'] })
+                  }
+                  options={[
+                    { label: 'Meaning', value: 'vector' },
+                    { label: 'Keyword', value: 'keyword' },
+                    { label: 'Hybrid', value: 'hybrid' }
+                  ]}
+                />
+              </SettingsRow>
               <SettingsRow label="CPU Threads" description="The number of CPU threads used for inference.">
                 <NumberField
                   ariaLabel="CPU threads"

--- a/src/shared/app-state.ts
+++ b/src/shared/app-state.ts
@@ -87,6 +87,7 @@ export interface LocalModel {
 export type AppTheme = 'light' | 'system'
 export type AppFontSize = 'small' | 'medium' | 'large'
 export type SuggestionMode = 'on' | 'off'
+export type SearchMode = 'vector' | 'keyword' | 'hybrid'
 export type ComputeDevice = 'applicationDefault' | 'cpu' | 'gpu'
 
 export interface ApplicationSettings {
@@ -94,6 +95,7 @@ export interface ApplicationSettings {
   fontSize: AppFontSize
   defaultModelId: string
   suggestionMode: SuggestionMode
+  searchMode: SearchMode
   followUpSuggestionCount: number
   showSources: boolean
   cpuThreads: number
@@ -138,7 +140,7 @@ export interface ChatSource {
   thumbnailPath?: string
   chunkSize?: number
   score?: number
-  retrievalMode?: 'vector' | 'starter'
+  retrievalMode?: 'vector' | 'keyword' | 'hybrid' | 'starter'
   embeddingModel?: string
   chunkEmbeddingModel?: string
 }

--- a/src/shared/bridge.ts
+++ b/src/shared/bridge.ts
@@ -4,7 +4,8 @@ import type {
   CourseMaterial,
   LocalModel,
   LocalModelRole,
-  MaterialIndexProgress
+  MaterialIndexProgress,
+  SearchMode
 } from './app-state'
 import type {
   CleaningPreviewResult,
@@ -40,7 +41,7 @@ export interface TokenSmithBridge {
   sendChatMessage: (request: EngineChatRequest) => Promise<EngineChatResponse>
   suggestChatQuestions: (request: EngineQuestionSuggestionRequest) => Promise<EngineQuestionSuggestionResponse>
   starterSources: (materials: CourseMaterial[], limit?: number) => Promise<ChatSource[]>
-  searchLibrary: (query: string, materials: CourseMaterial[], limit: number, embeddingModels?: LocalModel[]) => Promise<ChatSource[]>
+  searchLibrary: (query: string, materials: CourseMaterial[], limit: number, embeddingModels?: LocalModel[], searchMode?: SearchMode) => Promise<ChatSource[]>
   getPdfForSource: (source: ChatSource) => Promise<PdfSourceDocument>
   getPdfThumbnailForSource: (source: ChatSource) => Promise<PdfSourceThumbnail>
   getMarkdownForSource: (source: ChatSource) => Promise<MarkdownSourceDocument>

--- a/tests/integration/annita-demetriou-chat.test.mjs
+++ b/tests/integration/annita-demetriou-chat.test.mjs
@@ -192,7 +192,7 @@ try {
   assert.equal(chatResult.engineId, 'tokensmith')
   assert.ok(chatResult.sources.length >= 1, 'expected chat to retrieve at least one source')
   assert.match(chatResult.text, /local model is required/i)
-  assert.equal(chatResult.sources[0].retrievalMode, 'vector')
+  assert.equal(chatResult.sources[0].retrievalMode, 'hybrid')
   assert.match(chatResult.sources.map((source) => source.title).join('\n'), /Annita/i)
 
   console.log('Annita Demetriou PDF chat test passed.')

--- a/tests/integration/gerard-larcher-chat.test.mjs
+++ b/tests/integration/gerard-larcher-chat.test.mjs
@@ -192,7 +192,7 @@ try {
   assert.equal(chatResult.engineId, 'tokensmith')
   assert.ok(chatResult.sources.length >= 1, 'expected chat to retrieve at least one source')
   assert.match(chatResult.text, /local model is required/i)
-  assert.equal(chatResult.sources[0].retrievalMode, 'vector')
+  assert.equal(chatResult.sources[0].retrievalMode, 'hybrid')
   assert.match(chatResult.sources.map((source) => source.title).join('\n'), /Larcher/i)
 
   console.log('Gérard Larcher PDF chat test passed.')

--- a/tests/python/test_tokensmith_engine.py
+++ b/tests/python/test_tokensmith_engine.py
@@ -650,7 +650,10 @@ class TokenSmithEngineUnitTests(unittest.TestCase):
             }
         )
 
-        self.assertEqual(application_settings, {"cpuThreads": 8, "suggestionMode": "on", "followUpSuggestionCount": 4})
+        self.assertEqual(
+            application_settings,
+            {"cpuThreads": 8, "suggestionMode": "on", "followUpSuggestionCount": 4, "searchMode": "hybrid"},
+        )
         self.assertEqual(engine.normalize_application_settings({"suggestionMode": "localDocs"})["suggestionMode"], "on")
         self.assertEqual(
             engine.normalize_application_settings({"suggestionMode": "off", "followUpSuggestionCount": 4})[
@@ -666,6 +669,49 @@ class TokenSmithEngineUnitTests(unittest.TestCase):
         self.assertEqual(model_settings["temperature"], 0.4)
         self.assertNotIn("chatNamePrompt", model_settings)
         self.assertNotIn("answerStyle", model_settings)
+
+    def test_search_mode_normalizes_and_defaults_to_hybrid(self):
+        self.assertEqual(engine.normalize_search_mode("keyword"), "keyword")
+        self.assertEqual(engine.normalize_search_mode("HYBRID"), "hybrid")
+        self.assertEqual(engine.normalize_search_mode(None), "hybrid")
+        self.assertEqual(engine.normalize_search_mode("nonsense"), "hybrid")
+        self.assertEqual(engine.normalize_application_settings({})["searchMode"], "hybrid")
+        self.assertEqual(
+            engine.normalize_application_settings({"searchMode": "hybrid"})["searchMode"], "hybrid"
+        )
+
+    def test_combine_search_hits_uses_rrf_for_hybrid(self):
+        vector_hits = [(1, 0.9), (2, 0.8), (3, 0.7), (4, 0.6)]
+        keyword_hits = [(10, 5.0), (11, 4.0), (2, 3.0), (12, 2.0)]
+
+        vector_only = engine.combine_search_hits("vector", vector_hits, keyword_hits, 4)
+        self.assertEqual([rowid for rowid, _ in vector_only], [1, 2, 3, 4])
+
+        keyword_only = engine.combine_search_hits("keyword", vector_hits, keyword_hits, 4)
+        self.assertEqual([rowid for rowid, _ in keyword_only], [10, 11, 2, 12])
+
+        hybrid = engine.combine_search_hits("hybrid", vector_hits, keyword_hits, 4)
+        self.assertEqual(len(hybrid), 4)
+        self.assertIn(10, [rowid for rowid, _score in hybrid])
+        self.assertIn(11, [rowid for rowid, _score in hybrid])
+
+    def test_combine_search_hits_preserves_keyword_rank_order(self):
+        vector_hits = [(3, 0.9), (4, 0.8)]
+        keyword_hits = [(1, 1.0), (2, 5.0)]
+
+        keyword_only = engine.combine_search_hits("keyword", vector_hits, keyword_hits, 2)
+        self.assertEqual([rowid for rowid, _score in keyword_only], [1, 2])
+
+    def test_build_fts_match_query_is_operator_safe(self):
+        self.assertEqual(
+            store.build_fts_match_query(["poems", "friendship"]),
+            '"poems" OR "friendship"',
+        )
+        self.assertEqual(
+            store.build_fts_match_query(["poems", "friendship"], "AND"),
+            '"poems" "friendship"',
+        )
+        self.assertEqual(store.build_fts_match_query(["match?", "poems"]), '"poems"')
 
     def test_default_model_runtime_settings_match_tokensmith_defaults(self):
         settings = engine.normalize_model_runtime_settings({})
@@ -961,6 +1007,7 @@ class TokenSmithEngineUnitTests(unittest.TestCase):
                     "query": "What does third normal form remove?",
                     "materials": [material],
                     "limit": 2,
+                    "searchMode": "vector",
                     "userDataPath": str(temp_path / "user-data"),
                 }
             )

--- a/tests/python/test_tokensmith_keyword_search.py
+++ b/tests/python/test_tokensmith_keyword_search.py
@@ -1,0 +1,143 @@
+import tempfile
+import unittest
+
+from python_engine import tokensmith_store as store
+
+
+class KeywordSearchTests(unittest.TestCase):
+    def insert_material(self, conn, material_id, chunks):
+        conn.execute(
+            "INSERT INTO collections(id, name) VALUES (?, ?)",
+            (material_id, f"Material {material_id}"),
+        )
+        conn.execute(
+            "INSERT INTO folders(id, path) VALUES (?, ?)",
+            (material_id, f"/folder/{material_id}"),
+        )
+        conn.execute("INSERT INTO collection_items VALUES (?, ?)", (material_id, material_id))
+        conn.execute(
+            "INSERT INTO tokensmith_collection_state"
+            "(collection_id, status, is_active, added_at) VALUES (?, ?, ?, ?)",
+            (material_id, "ready", 1, store.now_iso()),
+        )
+        conn.execute(
+            "INSERT INTO documents(id, folder_id, document_time, document_path) VALUES (?, ?, 0, ?)",
+            (material_id, material_id, f"/folder/{material_id}/paper.pdf"),
+        )
+        rowids = []
+        for text in chunks:
+            cursor = conn.execute(
+                "INSERT INTO chunks(document_id, chunk_text, file) VALUES (?, ?, ?)",
+                (material_id, text, "paper.pdf"),
+            )
+            rowids.append(cursor.lastrowid)
+        return rowids
+
+    def test_filters_materials_before_limit(self):
+        with tempfile.TemporaryDirectory() as user_data_path:
+            store.init_db(user_data_path)
+            with store.connect(user_data_path) as conn:
+                for material_id, status, is_active in [
+                    (1, "ready", 1),
+                    (2, "ready", 1),
+                    (3, "ready", 0),
+                    (4, "indexing", 1),
+                ]:
+                    conn.execute("INSERT INTO collections(id, name) VALUES (?, ?)",
+                                 (material_id, f"Material {material_id}"))
+                    conn.execute("INSERT INTO folders(id, path) VALUES (?, ?)",
+                                 (material_id, f"/folder/{material_id}"))
+                    conn.execute("INSERT INTO collection_items VALUES (?, ?)",
+                                 (material_id, material_id))
+                    conn.execute(
+                        "INSERT INTO tokensmith_collection_state"
+                        "(collection_id, status, is_active, added_at) VALUES (?, ?, ?, ?)",
+                        (material_id, status, is_active, store.now_iso()),
+                    )
+                    conn.execute(
+                        "INSERT INTO documents(id, folder_id, document_time, document_path)"
+                        " VALUES (?, ?, 0, ?)",
+                        (material_id, material_id, f"/folder/{material_id}/paper.pdf"),
+                    )
+                # Each excluded material alone can fill the old limit * 8 window.
+                for material_id in (2, 3, 4):
+                    conn.executemany(
+                        "INSERT INTO chunks(document_id, chunk_text, file) VALUES (?, ?, ?)",
+                        [(material_id, "components", "paper.pdf")] * 20,
+                    )
+                expected = []
+                for text in ("components " + "background " * 30,
+                             "components " + "background " * 60):
+                    cursor = conn.execute(
+                        "INSERT INTO chunks(document_id, chunk_text, file) VALUES (1, ?, ?)",
+                        (text, "paper.pdf"),
+                    )
+                    expected.append(cursor.lastrowid)
+                # The same folder belongs to two selected collections.
+                conn.execute("INSERT INTO collection_items VALUES (2, 1)")
+
+            for selected in (["1"], ["1", "3", "4"]):
+                with self.subTest(selected=selected):
+                    hits = store.keyword_search(user_data_path, "components", selected, 2)
+                    self.assertEqual([rowid for rowid, _ in hits], expected)
+                    self.assertGreater(hits[0][1], hits[1][1])
+            with store.connect(user_data_path) as conn:
+                conn.execute("DELETE FROM chunks WHERE document_id = 2")
+            hits = store.keyword_search(user_data_path, "components", ["1", "2"], 2)
+            self.assertEqual([rowid for rowid, _ in hits], expected)
+            self.assertEqual(store.keyword_search(user_data_path, "components", ["1"], 1)[0][0], expected[0])
+            self.assertEqual(store.keyword_search(user_data_path, "components", [], 2), [])
+            self.assertEqual(store.keyword_search(user_data_path, "?!", ["1"], 2), [])
+            self.assertEqual(store.keyword_search(user_data_path, "unmatched", ["1"], 2), [])
+
+    def test_keyword_search_uses_rare_terms_instead_of_question_filler(self):
+        with tempfile.TemporaryDirectory() as user_data_path:
+            store.init_db(user_data_path)
+            with store.connect(user_data_path) as conn:
+                chunks = [
+                    "Why systems do not just use a generic cache.",
+                    "Alpha keeps the important frame resident while a worker is actively using it.",
+                ]
+                chunks.extend(
+                    f"Beta replacement chooses a victim frame in cache simulation example {index}."
+                    for index in range(20)
+                )
+                rowids = self.insert_material(
+                    conn,
+                    1,
+                    chunks,
+                )
+
+            query = "why cant we just do beta. what is the need for alpha"
+            terms = store.keyword_terms_for_query(user_data_path, query, ["1"])
+
+            self.assertEqual(terms[:2], ["alpha", "beta"])
+            self.assertNotIn("why", terms)
+            self.assertNotIn("the", terms)
+
+            hits = store.keyword_search(user_data_path, query, ["1"], 2)
+            self.assertEqual(hits[0][0], rowids[1])
+
+    def test_keyword_search_prefers_chunks_that_match_all_meaningful_terms(self):
+        with tempfile.TemporaryDirectory() as user_data_path:
+            store.init_db(user_data_path)
+            with store.connect(user_data_path) as conn:
+                rowids = self.insert_material(
+                    conn,
+                    1,
+                    [
+                        "Beta simulation question asks for an access pattern where beta beats gamma.",
+                        "Alpha prevents the beta policy from evicting a frame while a worker is using it.",
+                        "Alpha keeps active frames resident in the buffer pool.",
+                    ],
+                )
+
+            query = "why can't we just do beta, what is the need for alpha?"
+            hits = store.keyword_search(user_data_path, query, ["1"], 3)
+
+            self.assertEqual(hits[0][0], rowids[1])
+            self.assertIn(rowids[2], [rowid for rowid, _score in hits])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/typescript/study-chat-format.test.mjs
+++ b/tests/unit/typescript/study-chat-format.test.mjs
@@ -66,6 +66,19 @@ test('sourceContext uses a neutral context block without model-facing page locat
   assert.equal(sourceContext([databaseSource]).includes('Locator: Page 4'), false)
 })
 
+test('sourceContext prefers full chunk context over the short excerpt', () => {
+  const context = sourceContext([
+    {
+      ...databaseSource,
+      excerpt: 'Short excerpt only.',
+      context: 'Full chunk context explains why protection prevents unsafe replacement.'
+    }
+  ])
+
+  assert.match(context, /Full chunk context explains why protection prevents unsafe replacement/)
+  assert.doesNotMatch(context, /Short excerpt only/)
+})
+
 test('studyChatMessages includes system text, recent conversation, and retrieved source context', () => {
   const messages = Array.from({ length: 14 }, (_, index) => ({
     role: index % 2 === 0 ? 'user' : 'assistant',


### PR DESCRIPTION
## Summary
Retrieval is dense-only today — the BM25 index (`chunks_fts`) is built during indexing but never queried at search. This wires it into `search_library` and adds a **Search Mode** setting: Meaning (vector), Keyword (BM25), or Hybrid. Default stays Meaning; existing behavior is unchanged unless a user opts in.

## Motivation
Dense search ranks a chunk by its overall topic, so a query whose answer hinges on a specific term can miss when the answer chunk is *about* something else. On a test paper, *"the five main components of the KITE system"* ranks the answer chunk at 4 (just outside the kept top-4) under vector, and at 1 under keyword or hybrid — the question and the text share the exact word "components." Keyword can't match paraphrase, so it's an added mode, not a replacement.

## Changes
- **`tokensmith_store.py`** — `keyword_search()` (BM25 over `chunks_fts`) and `build_fts_match_query()` (operator-safe FTS5 MATCH).
- **`tokensmith_engine.py`** — `search_library` resolves a `searchMode`, runs vector and/or keyword, merges via `combine_search_hits()` (min-max normalized, 70/30 for hybrid); adds the `searchMode` setting.
- **Renderer / IPC** — Search Mode dropdown (Settings → Application → Advanced), threaded renderer → bridge → preload → main → Python.
- **Tests** — mode normalization, score blending, FTS query building.

## Design decisions
- Default stays Meaning — hybrid isn't universally better, so opt-in over silently changing everyone's results.
- A setting, not auto-detection — best mode depends on the document; explicit is simpler and predictable.
- 70/30 min-max blend so cosine and BM25 scores are comparable; weight is a named constant, easy to tune.

## Testing
- `npm run typecheck` (node + web) — clean
- Python unit tests — 60 pass (3 new)
- Manual end-to-end: default vector unchanged; keyword/hybrid surface the exact-term chunk at rank 1.