### PR TITLE
Fix Python runtime packaging and remove the system Python dependency

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -25,11 +25,6 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
       - name: Install system package tools
         run: sudo apt-get update && sudo apt-get install -y dpkg-dev curl
 
@@ -37,15 +32,7 @@ jobs:
         run: npm ci
 
       - name: Build Python runtime
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements-runtime.txt
-          PYTHON_ROOT="$(python -c 'import pathlib, sys; print(pathlib.Path(sys.executable).resolve().parents[1])')"
-          mkdir -p app_runtime
-          rsync -a --delete \
-            --exclude='__pycache__' \
-            --exclude='*.pyc' \
-            "$PYTHON_ROOT/" app_runtime/python/
+        run: npm run setup:python-runtime
 
       - name: Install AppImage tooling
         run: |
@@ -59,6 +46,17 @@ jobs:
         env:
           APPIMAGE_EXTRACT_AND_RUN: '1'
         run: npm run package:linux
+
+      - name: Verify packaged Python runtime
+        run: |
+          CHECK_ROOT="$(mktemp -d)"
+          DEB_PATH="$(find release -maxdepth 1 -name 'tokensmith_*.deb' -print -quit)"
+          dpkg-deb -x "$DEB_PATH" "$CHECK_ROOT"
+          RUNTIME="$CHECK_ROOT/opt/TokenSmith/resources/app/app_runtime/python"
+          test -x "$RUNTIME/bin/python"
+          test -z "$(find "$RUNTIME" -xtype l -print -quit)"
+          PYTHONHOME="$RUNTIME" LD_LIBRARY_PATH="$RUNTIME/lib" \
+            "$RUNTIME/bin/python" -c 'import faiss, jinja2, numpy, pypdfium2, PIL'
 
       - name: Upload Linux packages
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -25,27 +25,21 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
       - name: Install Node dependencies
         run: npm ci
 
       - name: Build Python runtime
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements-runtime.txt
-          PYTHON_ROOT="$(python -c 'import pathlib, sys; print(pathlib.Path(sys.executable).resolve().parents[1])')"
-          mkdir -p app_runtime
-          rsync -a --delete \
-            --exclude='__pycache__' \
-            --exclude='*.pyc' \
-            "$PYTHON_ROOT/" app_runtime/python/
+        run: npm run setup:python-runtime
 
       - name: Package macOS app
         run: npm run package:mac
+
+      - name: Verify packaged Python runtime
+        run: |
+          RUNTIME="release/mac/TokenSmith.app/Contents/Resources/app/app_runtime/python"
+          test -x "$RUNTIME/bin/python"
+          PYTHONHOME="$RUNTIME" DYLD_FALLBACK_LIBRARY_PATH="$RUNTIME/lib" \
+            "$RUNTIME/bin/python" -c 'import faiss, jinja2, numpy, pypdfium2, PIL'
 
       - name: Upload macOS package
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -25,29 +25,26 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
       - name: Install Node dependencies
         run: npm ci
 
       - name: Build Python runtime
-        shell: pwsh
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements-runtime.txt
-          $pythonRoot = Split-Path -Parent (Get-Command python).Source
-          New-Item -ItemType Directory -Force app_runtime | Out-Null
-          robocopy $pythonRoot app_runtime/python /MIR /XD __pycache__ /XF *.pyc
-          if ($LASTEXITCODE -gt 7) {
-            exit $LASTEXITCODE
-          }
-          exit 0
+        run: npm run setup:python-runtime
 
       - name: Package Windows app
         run: npm run package:win
+
+      - name: Verify packaged Python runtime
+        shell: pwsh
+        run: |
+          $python = 'release/win/TokenSmith/resources/app/app_runtime/python/python.exe'
+          if (-not (Test-Path $python)) {
+            throw "Packaged Python runtime was not found at $python"
+          }
+          & $python -c 'import faiss, jinja2, numpy, pypdfium2, PIL'
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
 
       - name: Upload Windows package
         if: github.event_name == 'workflow_dispatch'

--- a/README.md
+++ b/README.md
@@ -44,11 +44,23 @@ Install dependencies:
 npm install
 ```
 
-Build the local Python runtime used by development and packaging:
+Download the pinned, platform-specific Python runtime and install TokenSmith's
+Python dependencies inside it:
 
 ```sh
 npm run setup:python-runtime
 ```
+
+This creates `app_runtime/python` inside the repository. It does not require,
+modify, or install packages into your system Python. The download is selected
+for Linux x64, Windows x64, or macOS ARM64 and verified with SHA-256 before it
+is used.
+
+The runtime comes from Astral's
+[python-build-standalone](https://github.com/astral-sh/python-build-standalone)
+`install_only_stripped` archives. TokenSmith pins the Python version, release,
+target platform, and checksum rather than copying the developer's Python
+installation.
 
 Start the app locally:
 
@@ -64,6 +76,10 @@ npm test
 ```
 
 ## Packaging
+
+Packaging requires `npm run setup:python-runtime` first. Release workflows run
+that command automatically and include the private runtime in each application,
+so students do not need to install Python.
 
 Create a macOS DMG:
 

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,5 +1,7 @@
-faiss-cpu
-jinja2
-numpy
-Pillow>=10
-pypdfium2>=4.30
+faiss-cpu==1.15.0
+jinja2==3.1.6
+MarkupSafe==3.0.3
+numpy==2.5.2
+packaging==26.3
+Pillow==12.3.0
+pypdfium2==5.13.0

--- a/scripts/package-linux.mjs
+++ b/scripts/package-linux.mjs
@@ -59,20 +59,31 @@ async function copyIfExists(from, to) {
   await cp(from, to, {
     recursive: true,
     preserveTimestamps: true,
+    verbatimSymlinks: true,
     filter: (source) => !source.includes('__pycache__') && !source.endsWith('.pyc')
   })
 }
 
+function requirePythonRuntime(appRuntimePath) {
+  const pythonExecutable = join(appRuntimePath, 'python', 'bin', 'python')
+  if (!existsSync(pythonExecutable)) {
+    throw new Error('TokenSmith Python runtime was not found. Run npm run setup:python-runtime before packaging.')
+  }
+}
+
 async function prepareAppPayload(resourcesPath) {
   const appPayloadPath = join(resourcesPath, 'app')
+  const appRuntimePath = join(rootDir, 'app_runtime')
 
   await mkdir(appPayloadPath, { recursive: true })
   await cp(join(rootDir, 'out'), join(appPayloadPath, 'out'), {
     recursive: true,
-    preserveTimestamps: true
+    preserveTimestamps: true,
+    verbatimSymlinks: true
   })
   await copyIfExists(join(rootDir, 'python_engine'), join(appPayloadPath, 'python_engine'))
-  await copyIfExists(join(rootDir, 'app_runtime'), join(appPayloadPath, 'app_runtime'))
+  requirePythonRuntime(appRuntimePath)
+  await copyIfExists(appRuntimePath, join(appPayloadPath, 'app_runtime'))
   await writeJson(join(appPayloadPath, 'package.json'), {
     name: packageJson.name,
     version: appVersion,
@@ -97,7 +108,8 @@ async function preparePortableApp() {
   await mkdir(stagingDir, { recursive: true })
   await cp(electronDistPath, appDir, {
     recursive: true,
-    preserveTimestamps: true
+    preserveTimestamps: true,
+    verbatimSymlinks: true
   })
 
   await rm(appExePath, { recursive: true, force: true })
@@ -124,7 +136,7 @@ async function createDebPackage() {
   await mkdir(dirname(desktopPath), { recursive: true })
   await mkdir(dirname(iconPath), { recursive: true })
   await mkdir(dirname(launcherPath), { recursive: true })
-  await cp(appDir, optAppPath, { recursive: true, preserveTimestamps: true })
+  await cp(appDir, optAppPath, { recursive: true, preserveTimestamps: true, verbatimSymlinks: true })
 
   if (existsSync(iconPngPath)) {
     await copyFile(iconPngPath, iconPath)
@@ -155,7 +167,7 @@ Priority: optional
 Architecture: ${debArch}
 Maintainer: TokenSmith <support@tokensmith.local>
 Description: ${packageJson.description}
-Depends: libgtk-3-0, libnss3, libxss1, libasound2, libatk-bridge2.0-0, libdrm2, libgbm1, libxcomposite1, libxdamage1, libxrandr2, libxkbcommon0
+Depends: libgtk-3-0, libnss3, libxss1, libasound2, libatk-bridge2.0-0, libdrm2, libgbm1, libxcomposite1, libxdamage1, libxrandr2, libxkbcommon0, xdg-utils
 `,
     'utf8'
   )
@@ -178,7 +190,7 @@ async function createAppImage() {
 
   await rm(appImageRoot, { recursive: true, force: true })
   await mkdir(appImageRoot, { recursive: true })
-  await cp(appDir, optAppPath, { recursive: true, preserveTimestamps: true })
+  await cp(appDir, optAppPath, { recursive: true, preserveTimestamps: true, verbatimSymlinks: true })
 
   if (existsSync(iconPngPath)) {
     await copyFile(iconPngPath, iconPath)

--- a/scripts/package-mac.mjs
+++ b/scripts/package-mac.mjs
@@ -57,8 +57,15 @@ async function renameIfExists(from, to) {
   }
 
   await rm(to, { force: true, recursive: true })
-  await cp(from, to, { recursive: true, preserveTimestamps: true })
+  await cp(from, to, { recursive: true, preserveTimestamps: true, verbatimSymlinks: true })
   await rm(from, { recursive: true, force: true })
+}
+
+function requirePythonRuntime(appRuntimePath) {
+  const pythonExecutable = join(appRuntimePath, 'python', 'bin', 'python')
+  if (!existsSync(pythonExecutable)) {
+    throw new Error('TokenSmith Python runtime was not found. Run npm run setup:python-runtime before packaging.')
+  }
 }
 
 function runtimeMachOCandidates(directoryPath, pythonBinPath, candidates = []) {
@@ -187,18 +194,19 @@ async function prepareAppPayload(resourcesPath) {
   await mkdir(appPayloadPath, { recursive: true })
   await cp(join(rootDir, 'out'), join(appPayloadPath, 'out'), {
     recursive: true,
-    preserveTimestamps: true
+    preserveTimestamps: true,
+    verbatimSymlinks: true
   })
   await cp(join(rootDir, 'python_engine'), join(appPayloadPath, 'python_engine'), {
     recursive: true,
     preserveTimestamps: true,
+    verbatimSymlinks: true,
     filter: (source) => !source.includes('__pycache__') && !source.endsWith('.pyc')
   })
-  if (existsSync(appRuntimePath)) {
-    const packagedRuntimePath = join(appPayloadPath, 'app_runtime')
-    await run('/usr/bin/ditto', [appRuntimePath, packagedRuntimePath])
-    await patchMacPythonRuntime(packagedRuntimePath)
-  }
+  requirePythonRuntime(appRuntimePath)
+  const packagedRuntimePath = join(appPayloadPath, 'app_runtime')
+  await run('/usr/bin/ditto', [appRuntimePath, packagedRuntimePath])
+  await patchMacPythonRuntime(packagedRuntimePath)
   await writeJson(join(appPayloadPath, 'package.json'), {
     name: packageJson.name,
     version: appVersion,

--- a/scripts/package-win.mjs
+++ b/scripts/package-win.mjs
@@ -50,20 +50,31 @@ async function copyIfExists(from, to) {
   await cp(from, to, {
     recursive: true,
     preserveTimestamps: true,
+    verbatimSymlinks: true,
     filter: (source) => !source.includes('__pycache__') && !source.endsWith('.pyc')
   })
 }
 
+function requirePythonRuntime(appRuntimePath) {
+  const pythonExecutable = join(appRuntimePath, 'python', 'python.exe')
+  if (!existsSync(pythonExecutable)) {
+    throw new Error('TokenSmith Python runtime was not found. Run npm run setup:python-runtime before packaging.')
+  }
+}
+
 async function prepareAppPayload(resourcesPath) {
   const appPayloadPath = join(resourcesPath, 'app')
+  const appRuntimePath = join(rootDir, 'app_runtime')
 
   await mkdir(appPayloadPath, { recursive: true })
   await cp(join(rootDir, 'out'), join(appPayloadPath, 'out'), {
     recursive: true,
-    preserveTimestamps: true
+    preserveTimestamps: true,
+    verbatimSymlinks: true
   })
   await copyIfExists(join(rootDir, 'python_engine'), join(appPayloadPath, 'python_engine'))
-  await copyIfExists(join(rootDir, 'app_runtime'), join(appPayloadPath, 'app_runtime'))
+  requirePythonRuntime(appRuntimePath)
+  await copyIfExists(appRuntimePath, join(appPayloadPath, 'app_runtime'))
   await writeJson(join(appPayloadPath, 'package.json'), {
     name: packageJson.name,
     version: appVersion,
@@ -87,7 +98,8 @@ async function preparePortableApp() {
   await mkdir(stagingDir, { recursive: true })
   await cp(electronDistPath, appDir, {
     recursive: true,
-    preserveTimestamps: true
+    preserveTimestamps: true,
+    verbatimSymlinks: true
   })
 
   await rm(appExePath, { recursive: true, force: true })

--- a/scripts/python-dev.mjs
+++ b/scripts/python-dev.mjs
@@ -1,7 +1,13 @@
-import { copyFileSync, cpSync, existsSync, mkdirSync, readdirSync, rmSync, symlinkSync } from 'node:fs'
-import { basename, delimiter, dirname, join, relative, resolve } from 'node:path'
+import { createHash } from 'node:crypto'
+import { createReadStream, createWriteStream, existsSync, mkdirSync, readdirSync, renameSync, rmSync, symlinkSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import { standaloneRuntime } from './python-runtime-manifest.mjs'
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)))
 const appRuntimeRoot = join(root, 'app_runtime', 'python')
@@ -58,7 +64,7 @@ function inspectPython(python) {
   const code = [
     'import json, pathlib, sys',
     'executable = pathlib.Path(sys.executable).resolve()',
-    'root = executable.parents[1]',
+    'root = executable.parent if sys.platform == "win32" else executable.parents[1]',
     'print(json.dumps({',
     '  "executable": str(executable),',
     '  "root": str(root),',
@@ -89,63 +95,6 @@ function inspectPython(python) {
 function versionIsSupported(info) {
   const [major, minor] = info.version ?? []
   return major > 3 || (major === 3 && minor >= 10)
-}
-
-function isCondaPython(info) {
-  const normalizedRoot = resolve(info.root)
-  const loweredRoot = normalizedRoot.toLowerCase()
-  return (
-    existsSync(join(normalizedRoot, 'conda-meta')) ||
-    existsSync(join(normalizedRoot, 'pkgs')) ||
-    loweredRoot.includes('/miniforge') ||
-    loweredRoot.includes('/miniconda') ||
-    loweredRoot.includes('/anaconda')
-  )
-}
-
-function buildPythonCandidates() {
-  const candidates = []
-
-  if (process.platform === 'darwin') {
-    candidates.push(
-      '/opt/homebrew/opt/python@3.12/bin/python3.12',
-      '/usr/local/opt/python@3.12/bin/python3.12',
-      '/opt/homebrew/bin/python3.12',
-      '/usr/local/bin/python3.12'
-    )
-  }
-
-  candidates.push('python3.12', 'python3', 'python')
-  return [...new Set(candidates)]
-}
-
-function selectBuildPython() {
-  const skipped = []
-
-  for (const candidate of buildPythonCandidates()) {
-    const info = inspectPython(candidate)
-    if (!info) {
-      continue
-    }
-    if (!versionIsSupported(info)) {
-      skipped.push(`${candidate} (${info.version?.join('.') ?? 'unknown'} is too old)`)
-      continue
-    }
-    if (isCondaPython(info)) {
-      skipped.push(`${candidate} (${info.root} is a Conda root)`)
-      continue
-    }
-    return info
-  }
-
-  if (skipped.length) {
-    console.error('Skipped Python runtimes:')
-    for (const reason of skipped) {
-      console.error(`  - ${reason}`)
-    }
-  }
-
-  return null
 }
 
 function canRun(python, code) {
@@ -197,27 +146,6 @@ function runNode(script, args = []) {
   return result.status ?? 1
 }
 
-function copyRuntime(sourceRoot) {
-  rmSync(appRuntimeRoot, { recursive: true, force: true })
-  mkdirSync(dirname(appRuntimeRoot), { recursive: true })
-  cpSync(sourceRoot, appRuntimeRoot, {
-    recursive: true,
-    dereference: true,
-    preserveTimestamps: true,
-    filter: (source) => {
-      const name = basename(source)
-      return (
-        name !== '__pycache__' &&
-        name !== 'conda-meta' &&
-        name !== 'envs' &&
-        name !== 'EXTERNALLY-MANAGED' &&
-        name !== 'pkgs' &&
-        !source.endsWith('.pyc')
-      )
-    }
-  })
-}
-
 function ensureRuntimePythonAlias() {
   if (process.platform === 'win32' || existsSync(appRuntimePython)) {
     return
@@ -234,25 +162,25 @@ function ensureRuntimePythonAlias() {
 
   try {
     symlinkSync(pythonBinary, appRuntimePython)
-  } catch {
-    copyFileSync(join(binPath, pythonBinary), appRuntimePython)
+  } catch (error) {
+    throw new Error(`Could not create the TokenSmith Python executable alias: ${error.message}`)
   }
 }
 
 function runtimePythonLib() {
+  if (process.platform === 'win32') {
+    const windowsLib = join(appRuntimeRoot, 'Lib')
+    if (existsSync(windowsLib)) {
+      return windowsLib
+    }
+  }
+
   const libRoot = join(appRuntimeRoot, 'lib')
   const pythonLibName = readdirSync(libRoot).find((name) => /^python3\.\d+$/.test(name))
   if (!pythonLibName) {
     throw new Error(`Could not find Python stdlib under ${libRoot}.`)
   }
   return join(libRoot, pythonLibName)
-}
-
-function resetRuntimeSitePackages() {
-  const sitePackages = join(runtimePythonLib(), 'site-packages')
-  rmSync(sitePackages, { recursive: true, force: true })
-  mkdirSync(sitePackages, { recursive: true })
-  return sitePackages
 }
 
 function runCommand(command, args, { allowFailure = false } = {}) {
@@ -267,6 +195,82 @@ function runCommand(command, args, { allowFailure = false } = {}) {
   }
 
   return result
+}
+
+async function sha256(filePath) {
+  const hash = createHash('sha256')
+  const file = createReadStream(filePath)
+
+  for await (const chunk of file) {
+    hash.update(chunk)
+  }
+
+  return hash.digest('hex')
+}
+
+async function downloadFile(url, destination) {
+  const response = await fetch(url, { redirect: 'follow' })
+  if (!response.ok || !response.body) {
+    throw new Error(`Could not download the Python runtime: HTTP ${response.status} ${response.statusText}.`)
+  }
+
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(destination))
+}
+
+async function downloadStandaloneRuntime() {
+  const runtime = standaloneRuntime()
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'tokensmith-python-runtime-'))
+  const archivePath = join(temporaryDirectory, runtime.filename)
+
+  try {
+    console.log(`[python-runtime] Downloading Python ${runtime.pythonVersion} for ${runtime.key}.`)
+    await downloadFile(runtime.url, archivePath)
+
+    const actualSha256 = await sha256(archivePath)
+    if (actualSha256 !== runtime.sha256) {
+      throw new Error(`Python runtime checksum mismatch: expected ${runtime.sha256}, received ${actualSha256}.`)
+    }
+
+    rmSync(appRuntimeRoot, { recursive: true, force: true })
+    mkdirSync(dirname(appRuntimeRoot), { recursive: true })
+    runCommand('tar', ['-xzf', archivePath, '-C', dirname(appRuntimeRoot)])
+
+    if (!existsSync(appRuntimeRoot)) {
+      throw new Error(`The Python runtime archive did not contain the expected ${appRuntimeRoot} directory.`)
+    }
+
+    console.log(`[python-runtime] Verified ${runtime.filename}.`)
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+}
+
+function installRuntimeDependencies(python) {
+  const sitePackages = join(runtimePythonLib(), 'site-packages')
+  const temporarySitePackages = join(appRuntimeRoot, '.tokensmith-site-packages')
+  rmSync(temporarySitePackages, { recursive: true, force: true })
+
+  const status = runPython(python, [
+    '-m',
+    'pip',
+    'install',
+    '--disable-pip-version-check',
+    '--no-compile',
+    '--target',
+    temporarySitePackages,
+    '-r',
+    'requirements-runtime.txt'
+  ], { PYTHONNOUSERSITE: '1' })
+
+  if (status !== 0) {
+    rmSync(temporarySitePackages, { recursive: true, force: true })
+    return status
+  }
+
+  rmSync(sitePackages, { recursive: true, force: true })
+  mkdirSync(dirname(sitePackages), { recursive: true })
+  renameSync(temporarySitePackages, sitePackages)
+  return 0
 }
 
 function runtimeMachOCandidates(directoryPath, pythonBinPath, candidates = []) {
@@ -381,24 +385,9 @@ function patchMacPythonRuntime() {
   console.log('[python-runtime] Rewrote and signed bundled Python framework links.')
 }
 
-function setup() {
-  const buildPythonInfo = selectBuildPython()
-
-  if (!buildPythonInfo || !versionIsSupported(buildPythonInfo)) {
-    console.error('No usable Python 3.10+ runtime was found for building app_runtime.')
-    console.error('Install a non-Conda Python 3.10+ runtime, then run npm run setup:python-runtime again.')
-    process.exit(1)
-  }
-
-  if (isCondaPython(buildPythonInfo)) {
-    console.error(`Refusing to build app_runtime from Conda root: ${buildPythonInfo.root}`)
-    process.exit(1)
-  }
-
-  console.log(`[python-runtime] Copying clean Python ${buildPythonInfo.root} -> ${appRuntimeRoot}`)
-  copyRuntime(buildPythonInfo.root)
+async function setup() {
+  await downloadStandaloneRuntime()
   ensureRuntimePythonAlias()
-  const sitePackages = resetRuntimeSitePackages()
   patchMacPythonRuntime()
 
   if (!existsSync(appRuntimePython)) {
@@ -415,21 +404,8 @@ function setup() {
     console.error(`Copied runtime resolved outside app_runtime: ${runtimeInfo.root}`)
     process.exit(1)
   }
-  if (isCondaPython(runtimeInfo)) {
-    console.error(`Copied runtime still looks like Conda: ${runtimeInfo.root}`)
-    process.exit(1)
-  }
 
-  let status = runPython(buildPythonInfo.executable, [
-    '-m',
-    'pip',
-    'install',
-    '--upgrade',
-    '--target',
-    sitePackages,
-    '-r',
-    'requirements-runtime.txt'
-  ], { PYTHONNOUSERSITE: '1' })
+  let status = installRuntimeDependencies(appRuntimePython)
   if (status !== 0) {
     process.exit(1)
   }
@@ -474,7 +450,7 @@ function runIntegration({ requireGguf = false } = {}) {
 }
 
 if (task === 'setup' || task === 'setup-runtime') {
-  setup()
+  await setup()
 } else if (task === 'unit') {
   const python = requireRuntimePython()
   process.exit(runPython(python.executable, ['-m', 'unittest', 'discover', '-s', 'tests/python', '-p', 'test_*.py']))

--- a/scripts/python-runtime-manifest.mjs
+++ b/scripts/python-runtime-manifest.mjs
@@ -1,0 +1,41 @@
+// Pinned install_only_stripped archives published by Astral's
+// python-build-standalone project. Update the filename and SHA-256 together.
+const releaseTag = '20260901'
+const releaseBaseUrl = `https://github.com/astral-sh/python-build-standalone/releases/download/${releaseTag}`
+
+const runtimes = {
+  'linux-x64': {
+    filename: 'cpython-3.12.14+20260901-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz',
+    sha256: '72748da13197c1fb161e3afeef20a6a385ff24f2165e6e2758e47008e7faba4c'
+  },
+  'darwin-arm64': {
+    filename: 'cpython-3.12.14+20260901-aarch64-apple-darwin-install_only_stripped.tar.gz',
+    sha256: '81a359f1cfadd4da11766534c5913791cea55f26e1bb902cacd2a531bb1e4b2b'
+  },
+  'win32-x64': {
+    filename: 'cpython-3.12.14+20260901-x86_64-pc-windows-msvc-install_only_stripped.tar.gz',
+    sha256: '7c45c9622400d578709a9b2cddbe8124cc21d382409d9f13406d706d28e31b14'
+  }
+}
+
+export function runtimeKey(platform = process.platform, arch = process.arch) {
+  return `${platform}-${arch}`
+}
+
+export function standaloneRuntime(platform = process.platform, arch = process.arch) {
+  const key = runtimeKey(platform, arch)
+  const runtime = runtimes[key]
+
+  if (!runtime) {
+    const supported = Object.keys(runtimes).join(', ')
+    throw new Error(`TokenSmith does not provide a Python runtime for ${key}. Supported targets: ${supported}.`)
+  }
+
+  return {
+    ...runtime,
+    key,
+    pythonVersion: '3.12.14',
+    releaseTag,
+    url: `${releaseBaseUrl}/${runtime.filename.replace('+', '%2B')}`
+  }
+}

--- a/src/main/python/python-engine-service.ts
+++ b/src/main/python/python-engine-service.ts
@@ -183,27 +183,27 @@ function logSource(source: ChatSource): Record<string, unknown> {
   }
 }
 
-function getPythonExecutable(): string {
-  const runtimeCandidates =
-    process.platform === 'win32'
-      ? [
-          join(app.getAppPath(), 'app_runtime', 'python', 'python.exe'),
-          join(app.getAppPath(), 'app_runtime', 'python', 'Scripts', 'python.exe'),
-          join(process.resourcesPath, 'app', 'app_runtime', 'python', 'python.exe'),
-          join(process.resourcesPath, 'app', 'app_runtime', 'python', 'Scripts', 'python.exe')
-        ]
-      : [
-          join(app.getAppPath(), 'app_runtime', 'python', 'bin', 'python'),
-          join(process.resourcesPath, 'app', 'app_runtime', 'python', 'bin', 'python')
-        ]
+function getPythonRuntimeRoot(): string {
+  return app.isPackaged
+    ? join(process.resourcesPath, 'app', 'app_runtime', 'python')
+    : join(app.getAppPath(), 'app_runtime', 'python')
+}
 
-  for (const candidate of runtimeCandidates) {
-    if (existsSync(candidate)) {
-      return candidate
-    }
+function getPythonExecutable(): string {
+  const runtimeRoot = getPythonRuntimeRoot()
+  const pythonExecutable = process.platform === 'win32'
+    ? join(runtimeRoot, 'python.exe')
+    : join(runtimeRoot, 'bin', 'python')
+
+  if (existsSync(pythonExecutable)) {
+    return pythonExecutable
   }
 
-  throw new Error('The bundled TokenSmith Python runtime was not found. Run npm run setup:python-runtime before starting the app locally.')
+  throw new Error(
+    app.isPackaged
+      ? 'The TokenSmith installation is incomplete because its private Python runtime is missing. Reinstall TokenSmith.'
+      : 'The TokenSmith Python runtime was not found. Run npm run setup:python-runtime before starting the app locally.'
+  )
 }
 
 function getWorkerPath(): string {

--- a/tests/unit/typescript/python-runtime-manifest.test.mjs
+++ b/tests/unit/typescript/python-runtime-manifest.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { standaloneRuntime } from '../../../scripts/python-runtime-manifest.mjs'
+
+test('selects the pinned Linux x64 runtime', () => {
+  const runtime = standaloneRuntime('linux', 'x64')
+
+  assert.equal(runtime.pythonVersion, '3.12.14')
+  assert.match(runtime.filename, /x86_64-unknown-linux-gnu-install_only_stripped\.tar\.gz$/)
+  assert.match(runtime.url, /releases\/download\/20260901\//)
+  assert.match(runtime.sha256, /^[a-f0-9]{64}$/)
+})
+
+test('selects platform-specific runtimes', () => {
+  assert.match(standaloneRuntime('darwin', 'arm64').filename, /aarch64-apple-darwin/)
+  assert.match(standaloneRuntime('win32', 'x64').filename, /x86_64-pc-windows-msvc/)
+})
+
+test('rejects unsupported targets instead of using system Python', () => {
+  assert.throws(
+    () => standaloneRuntime('linux', 'riscv64'),
+    /does not provide a Python runtime for linux-riscv64/
+  )
+})
+
+test('runtime Python dependencies are exactly pinned', async () => {
+  const requirements = await readFile(new URL('../../../requirements-runtime.txt', import.meta.url), 'utf8')
+  const entries = requirements
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+
+  assert.ok(entries.length > 0)
+  for (const entry of entries) {
+    assert.match(entry, /^[A-Za-z0-9_.-]+==[A-Za-z0-9_.!+*-]+$/)
+  }
+})


### PR DESCRIPTION
## Problem

TokenSmith previously created its bundled Python runtime by copying an available
Python installation from the build machine. This caused several problems:

- Building TokenSmith required a compatible system Python installation.
- The packaged runtime depended on the build machine's Python version and directory layout.
- Some paths or symlinks could continue referencing the GitHub Actions runner's hosted-tool-cache directory, which does not exist on users' computers.
- Copying the Python installation could include unnecessary files.
- Any Python version newer than 3.10 was accepted, including untested future versions.
- Python dependencies were not pinned, making builds difficult to reproduce.
- A copied system Python installation was not guaranteed to remain portable after packaging.

These problems could leave installed applications unable to find or start their
bundled Python runtime.

## Solution

- Download a pinned, platform-specific Python runtime from `python-build-standalone`.
- Verify the downloaded archive using its SHA-256 checksum.
- Pin TokenSmith's Python dependency versions.
- Install dependencies inside TokenSmith's private runtime.
- Preserve runtime symlinks during packaging.
- Use deterministic runtime paths in development and packaged applications.
- Add packaged-runtime verification to the Linux, macOS, and Windows workflows.
- Provide clearer errors for missing development and packaged runtimes.
- Document the new development and packaging process.

End users can install and open TokenSmith without installing Python separately.

## Validation

- TypeScript unit tests: 8 passed
- Python unit tests: 59 passed
- Node and web typechecks passed
- Production build passed
- Python PDF integration test passed
- Fresh runtime download and SHA-256 verification passed
- Pinned dependency installation passed
- Linux `.deb` packaging passed
- The Python runtime extracted from the `.deb` successfully imported:
  - `faiss`
  - `jinja2`
  - `numpy`
  - `pypdfium2`
  - `PIL`

## Testing limitations

- The GGUF integration test was skipped because no embedding model was configured.
- AppImage packaging was not tested locally because `appimagetool` was unavailable.
- The macOS and Windows packaged-runtime checks will run in their respective GitHub Actions workflows.